### PR TITLE
Implement multi-context texture upload orchestration

### DIFF
--- a/AlmondShell/include/acontext.hpp
+++ b/AlmondShell/include/acontext.hpp
@@ -32,6 +32,7 @@
 #include "aatomicfunction.hpp"  // AlmondAtomicFunction
 #include "acommandqueue.hpp"    // CommandQueue
 #include "awindowdata.hpp"      // WindowData
+#include "acontexttype.hpp"     // ContextType enum
 
 #include <map>
 #include <memory>

--- a/AlmondShell/include/acontexttype.hpp
+++ b/AlmondShell/include/acontexttype.hpp
@@ -5,10 +5,12 @@ namespace almondnamespace::core {
     enum class ContextType {
         None = 0,
         OpenGL,
-        Software,
         SDL,
         SFML,
         RayLib,
+        Vulkan,
+        DirectX,
+        Software,
         Custom,
         Noop
     };

--- a/AlmondShell/include/aopenglcontext.hpp
+++ b/AlmondShell/include/aopenglcontext.hpp
@@ -319,9 +319,10 @@ namespace almondnamespace::openglcontext
         // -----------------------------------------------------------------
         // Step 9: Hook texture uploads
         // -----------------------------------------------------------------
-        atlasmanager::ensure_uploaded_backend = [](const TextureAtlas& atlas) {
-            opengltextures::ensure_uploaded(atlas);
-            };
+        atlasmanager::register_backend_uploader(core::ContextType::OpenGL,
+            [](const TextureAtlas& atlas) {
+                opengltextures::ensure_uploaded(atlas);
+            });
 
         // -----------------------------------------------------------------
         // Step 10: Sync context with GL state
@@ -360,6 +361,8 @@ namespace almondnamespace::openglcontext
     {
         auto& backend = opengltextures::get_opengl_backend();
         auto& glState = backend.glState;
+
+        atlasmanager::process_pending_uploads(core::ContextType::OpenGL);
 
         if (!ctx.hdc || !ctx.hglrc) {
             std::cerr << "[OpenGL] Context not ready (hdc=" << ctx.hdc

--- a/AlmondShell/include/aopengltextures.hpp
+++ b/AlmondShell/include/aopengltextures.hpp
@@ -262,7 +262,7 @@ namespace almondnamespace::opengltextures
     }
 
     inline Handle load_atlas(TextureAtlas& atlas, int atlasIndex = 0) {
-        upload_atlas_to_gpu(atlas);
+        atlasmanager::ensure_uploaded(atlas);
         return make_handle(atlasIndex, 0);
     }
 
@@ -280,7 +280,7 @@ namespace almondnamespace::opengltextures
             throw std::runtime_error("atlas_add_texture: Failed to add texture: " + id);
         }
 
-        upload_atlas_to_gpu(atlas);
+        atlasmanager::ensure_uploaded(atlas);
 
         int localIdx = static_cast<int>(atlas.entries.size() - 1);
         return make_handle(0, localIdx);

--- a/AlmondShell/include/araylibcontext.hpp
+++ b/AlmondShell/include/araylibcontext.hpp
@@ -38,6 +38,7 @@
 #include "aimageloader.hpp"
 #include "araylibtextures.hpp" // AtlasGPU, gpu_atlases, ensure_uploaded
 #include "araylibstate.hpp" // brings in the actual inline s_state
+#include "aatlasmanager.hpp"
 #include "araylibrenderer.hpp" // RendererContext, RenderMode
 #include "acommandline.hpp" // cli::window_width, cli::window_height
 #include "araylibcontextinput.hpp" // poll_input()
@@ -159,6 +160,12 @@ namespace almondnamespace::raylibcontext
         }
 
         s_raylibstate.running = true;
+
+        atlasmanager::register_backend_uploader(core::ContextType::RayLib,
+            [](const TextureAtlas& atlas) {
+                raylibtextures::ensure_uploaded(atlas);
+            });
+
         return true;
 
 //        //InitRaylibWindow();
@@ -239,6 +246,8 @@ namespace almondnamespace::raylibcontext
             s_raylibstate.running = false;
             return true;
         }
+
+        atlasmanager::process_pending_uploads(core::ContextType::RayLib);
 
         if (!wglMakeCurrent(s_raylibstate.hdc, s_raylibstate.glContext)) {
             s_raylibstate.running = false;

--- a/AlmondShell/include/araylibtextures.hpp
+++ b/AlmondShell/include/araylibtextures.hpp
@@ -200,7 +200,7 @@ namespace almondnamespace::raylibtextures
     }
 
     inline Handle load_atlas(TextureAtlas& atlas, int atlasIndex = 0) {
-        upload_atlas_to_gpu(atlas);
+        atlasmanager::ensure_uploaded(atlas);
         return make_handle(atlasIndex, 0);
     }
 
@@ -218,7 +218,7 @@ namespace almondnamespace::raylibtextures
             throw std::runtime_error("atlas_add_texture: Failed to add texture: " + id);
         }
 
-        upload_atlas_to_gpu(atlas);
+        atlasmanager::ensure_uploaded(atlas);
 
         int localIdx = static_cast<int>(atlas.entries.size() - 1);
         return make_handle(0, localIdx);

--- a/AlmondShell/include/asdlcontext.hpp
+++ b/AlmondShell/include/asdlcontext.hpp
@@ -41,6 +41,7 @@
 #include "acontextwindow.hpp"
 #include "asdlcontextrenderer.hpp"
 #include "asdltextures.hpp"
+#include "aatlasmanager.hpp"
 #include "asdlstate.hpp"
 
 #include <stdexcept>
@@ -189,6 +190,11 @@ namespace almondnamespace::sdlcontext
         SDL_ShowWindow(sdlcontext.window);
         sdlcontext.running = true;
 
+        atlasmanager::register_backend_uploader(core::ContextType::SDL,
+            [](const TextureAtlas& atlas) {
+                sdlcontext::ensure_uploaded(atlas);
+            });
+
 
         //SDL_Window* sdlParent = SDL_GetWindowParent(ctx.window);
         //if (sdlParent) {
@@ -252,7 +258,10 @@ namespace almondnamespace::sdlcontext
 
     inline bool sdl_process(core::Context& ctx, core::CommandQueue& queue) {
         if (!sdlcontext.running || !sdlcontext.renderer) return false;
-       // SDL_PumpEvents(); // Update SDL's internal state
+
+        atlasmanager::process_pending_uploads(core::ContextType::SDL);
+
+        // SDL_PumpEvents(); // Update SDL's internal state
         const bool* keys = SDL_GetKeyboardState(NULL);
         SDL_Event e;
         static int i = 0;

--- a/AlmondShell/include/asdltextures.hpp
+++ b/AlmondShell/include/asdltextures.hpp
@@ -196,7 +196,7 @@ namespace almondnamespace::sdlcontext
     }
 
     inline Handle load_atlas(TextureAtlas& atlas, int atlasIndex = 0) {
-        upload_atlas_to_gpu(atlas);
+        atlasmanager::ensure_uploaded(atlas);
         return make_handle(atlasIndex, 0);
     }
 
@@ -214,7 +214,7 @@ namespace almondnamespace::sdlcontext
             throw std::runtime_error("atlas_add_texture: Failed to add: " + id);
         }
 
-        upload_atlas_to_gpu(atlas);
+        atlasmanager::ensure_uploaded(atlas);
 
         int localIdx = static_cast<int>(atlas.entries.size() - 1);
         return make_handle(0, localIdx);

--- a/AlmondShell/include/asfmlcontext.hpp
+++ b/AlmondShell/include/asfmlcontext.hpp
@@ -34,6 +34,8 @@
 #include "acontext.hpp"
 #include "acontextwindow.hpp"
 #include "acommandline.hpp"
+#include "asfmltextures.hpp"
+#include "aatlasmanager.hpp"
 
 #include <iostream>
 #include <string>
@@ -244,6 +246,12 @@ namespace almondnamespace::sfmlcontext
         std::cout << "[SFML] HGLRC: " << sfmlcontext.glContext << "\n";
 
         sfmlcontext.running = true;
+
+        atlasmanager::register_backend_uploader(core::ContextType::SFML,
+            [](const TextureAtlas& atlas) {
+                sfmlcontext::ensure_uploaded(atlas);
+            });
+
         return true;
     }
 
@@ -295,6 +303,8 @@ namespace almondnamespace::sfmlcontext
 
 
         if (!sfmlcontext.running || !sfmlcontext.window || !sfmlcontext.window->isOpen()) return 1;
+
+        atlasmanager::process_pending_uploads(core::ContextType::SFML);
 
         // ⚠️ This makes the GL context active for SFML’s thread
         if (!wglMakeCurrent(sfmlcontext.hdc, sfmlcontext.glContext)) {

--- a/AlmondShell/include/asfmltextures.hpp
+++ b/AlmondShell/include/asfmltextures.hpp
@@ -170,7 +170,7 @@ namespace almondnamespace::sfmlcontext
     }
 
     inline Handle load_atlas(TextureAtlas& atlas, int atlasIndex = 0) {
-        upload_atlas_to_gpu(atlas);
+        atlasmanager::ensure_uploaded(atlas);
         return make_handle(atlasIndex, 0);
     }
 
@@ -187,7 +187,7 @@ namespace almondnamespace::sfmlcontext
             throw std::runtime_error("atlas_add_texture: Failed to add: " + id);
         }
 
-        upload_atlas_to_gpu(atlas);
+        atlasmanager::ensure_uploaded(atlas);
 
         int localIdx = static_cast<int>(atlas.entries.size() - 1);
         return make_handle(0, localIdx);

--- a/AlmondShell/include/asoftrenderer_context.hpp
+++ b/AlmondShell/include/asoftrenderer_context.hpp
@@ -33,6 +33,7 @@
 #include "asoftrenderer_state.hpp"
 #include "asoftrenderer_textures.hpp"
 #include "asoftrenderer_renderer.hpp"
+#include "aatlasmanager.hpp"
 
 #include <memory>
 #include <chrono>
@@ -92,6 +93,14 @@ namespace almondnamespace::anativecontext
 #endif
 
         std::cout << "[SoftRenderer] Initialized on HWND=" << ctx->hwnd << "\n";
+
+        atlasmanager::register_backend_uploader(core::ContextType::Software,
+            [](const TextureAtlas& atlas) {
+                if (atlas.pixel_data.empty()) {
+                    const_cast<TextureAtlas&>(atlas).rebuild_pixels();
+                }
+            });
+
         return true;
     }
 
@@ -130,6 +139,8 @@ namespace almondnamespace::anativecontext
     // Main process loop
     inline bool softrenderer_process(core::Context& ctx, core::CommandQueue& queue) {
         auto& sr = s_softrendererstate;
+
+        atlasmanager::process_pending_uploads(core::ContextType::Software);
 
         // Clear framebuffer
         std::fill(sr.framebuffer.begin(), sr.framebuffer.end(), 0xFF000000);

--- a/AlmondShell/src/acontext.cpp
+++ b/AlmondShell/src/acontext.cpp
@@ -73,6 +73,7 @@
 
 #include "aimageloader.hpp"
 #include "aatlastexture.hpp"
+#include "aatlasmanager.hpp"
 
 #include <iostream>
 #include <stdexcept>
@@ -190,7 +191,11 @@ namespace almondnamespace::core {
 #ifdef ALMOND_USING_OPENGL
     inline void opengl_initialize() {}
     inline void opengl_cleanup() {}
-    bool opengl_process(Context& ctx, CommandQueue& queue) { queue.drain(); return true; }
+    bool opengl_process(Context& ctx, CommandQueue& queue) {
+        atlasmanager::process_pending_uploads(ctx.type);
+        queue.drain();
+        return true;
+    }
     inline void opengl_clear() {}
     inline void opengl_present() {}
     inline int  opengl_get_width() { return 1280; }
@@ -200,7 +205,11 @@ namespace almondnamespace::core {
 #ifdef ALMOND_USING_SDL
     inline void sdl_initialize() {}
     inline void sdl_cleanup() {}
-    bool sdl_process(Context& ctx, CommandQueue& queue) { queue.drain(); return true; }
+    bool sdl_process(Context& ctx, CommandQueue& queue) {
+        atlasmanager::process_pending_uploads(ctx.type);
+        queue.drain();
+        return true;
+    }
     inline void sdl_clear() {}
     inline void sdl_present() {}
     inline int  sdl_get_width() { return 1280; }
@@ -210,7 +219,11 @@ namespace almondnamespace::core {
 #ifdef ALMOND_USING_SFML
     inline void sfml_initialize() {}
     inline void sfml_cleanup() {}
-    bool sfml_process(Context& ctx, CommandQueue& queue) { queue.drain(); return true; }
+    bool sfml_process(Context& ctx, CommandQueue& queue) {
+        atlasmanager::process_pending_uploads(ctx.type);
+        queue.drain();
+        return true;
+    }
     inline void sfml_clear() {}
     inline void sfml_present() {}
     inline int  sfml_get_width() { return 1280; }
@@ -220,7 +233,11 @@ namespace almondnamespace::core {
 #ifdef ALMOND_USING_RAYLIB
     inline void raylib_initialize() {}
     inline void raylib_cleanup() {}
-    bool raylib_process(Context& ctx, CommandQueue& queue) { queue.drain(); return true; }
+    bool raylib_process(Context& ctx, CommandQueue& queue) {
+        atlasmanager::process_pending_uploads(ctx.type);
+        queue.drain();
+        return true;
+    }
     inline void raylib_clear() {}
     inline void raylib_present() {}
     inline int  raylib_get_width() { return 1280; }
@@ -230,7 +247,11 @@ namespace almondnamespace::core {
 #ifdef ALMOND_USING_VULKAN
     inline void vulkan_initialize() {}
     inline void vulkan_cleanup() {}
-    bool vulkan_process(Context& ctx, CommandQueue& queue) { queue.drain(); return true; }
+    bool vulkan_process(Context& ctx, CommandQueue& queue) {
+        atlasmanager::process_pending_uploads(ctx.type);
+        queue.drain();
+        return true;
+    }
     inline void vulkan_clear() {}
     inline void vulkan_present() {}
     inline int  vulkan_get_width() { return 1280; }
@@ -240,7 +261,11 @@ namespace almondnamespace::core {
 #ifdef ALMOND_USING_DIRECTX
     inline void directx_initialize() {}
     inline void directx_cleanup() {}
-    bool directx_process(Context& ctx, CommandQueue& queue) { queue.drain(); return true; }
+    bool directx_process(Context& ctx, CommandQueue& queue) {
+        atlasmanager::process_pending_uploads(ctx.type);
+        queue.drain();
+        return true;
+    }
     inline void directx_clear() {}
     inline void directx_present() {}
     inline int  directx_get_width() { return 1280; }
@@ -250,7 +275,11 @@ namespace almondnamespace::core {
 #ifdef ALMOND_USING_CUSTOM
     inline void custom_initialize() {}
     inline void custom_cleanup() {}
-    bool custom_process(Context& ctx, CommandQueue& queue) { queue.drain(); return true; }
+    bool custom_process(Context& ctx, CommandQueue& queue) {
+        atlasmanager::process_pending_uploads(ctx.type);
+        queue.drain();
+        return true;
+    }
     inline void custom_clear() {}
     inline void custom_present() {}
     inline int  custom_get_width() { return 1280; }
@@ -260,7 +289,11 @@ namespace almondnamespace::core {
 #ifdef ALMOND_USING_SOFTWARE_RENDERER
     inline void softrenderer_initialize() {}
     inline void softrenderer_cleanup() {}
-    bool softrenderer_process(Context& ctx, CommandQueue& queue) { queue.drain(); return true; }
+    bool softrenderer_process(Context& ctx, CommandQueue& queue) {
+        atlasmanager::process_pending_uploads(ctx.type);
+        queue.drain();
+        return true;
+    }
     inline void softrenderer_clear() {}
     inline void softrenderer_present() {}
     inline int  softrenderer_get_width() { return 800; }


### PR DESCRIPTION
## Summary
- add a centralized atlas upload service that tracks pending texture work per backend
- register OpenGL, SDL, SFML, Raylib, and software contexts with the service and flush uploads from their render loops
- route atlas load/add paths through the queued uploader so new textures are synchronized across contexts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d45557ff708333962214114114bb16