### PR TITLE
Improve atlas manager concurrency and multi-context uploads

### DIFF
--- a/AlmondShell/include/aguimenu.hpp
+++ b/AlmondShell/include/aguimenu.hpp
@@ -188,8 +188,8 @@ namespace almondnamespace::menu
 
             if (auto* win = ctx->windowData) {
                 win->commandQueue.enqueue([atlas = &registrar->atlas]() {
-                    opengltextures::ensure_uploaded(*atlas);
-                    });
+                    atlasmanager::ensure_uploaded(*atlas);
+                });
             }
 
             constexpr int expectedColumns = 4;

--- a/AlmondShell/include/aopengltextures.hpp
+++ b/AlmondShell/include/aopengltextures.hpp
@@ -261,7 +261,7 @@ namespace almondnamespace::opengltextures
         s_generation.fetch_add(1, std::memory_order_relaxed);
     }
 
-    inline Handle load_atlas(TextureAtlas& atlas, int atlasIndex = 0) {
+    inline Handle load_atlas(const TextureAtlas& atlas, int atlasIndex = 0) {
         atlasmanager::ensure_uploaded(atlas);
         return make_handle(atlasIndex, 0);
     }

--- a/AlmondShell/include/araylibtextures.hpp
+++ b/AlmondShell/include/araylibtextures.hpp
@@ -199,7 +199,7 @@ namespace almondnamespace::raylibtextures
         s_generation.fetch_add(1, std::memory_order_relaxed);
     }
 
-    inline Handle load_atlas(TextureAtlas& atlas, int atlasIndex = 0) {
+    inline Handle load_atlas(const TextureAtlas& atlas, int atlasIndex = 0) {
         atlasmanager::ensure_uploaded(atlas);
         return make_handle(atlasIndex, 0);
     }

--- a/AlmondShell/include/asdltextures.hpp
+++ b/AlmondShell/include/asdltextures.hpp
@@ -195,7 +195,7 @@ namespace almondnamespace::sdlcontext
         upload_atlas_to_gpu(atlas);
     }
 
-    inline Handle load_atlas(TextureAtlas& atlas, int atlasIndex = 0) {
+    inline Handle load_atlas(const TextureAtlas& atlas, int atlasIndex = 0) {
         atlasmanager::ensure_uploaded(atlas);
         return make_handle(atlasIndex, 0);
     }

--- a/AlmondShell/include/asfmltextures.hpp
+++ b/AlmondShell/include/asfmltextures.hpp
@@ -169,7 +169,7 @@ namespace almondnamespace::sfmlcontext
         s_generation.fetch_add(1, std::memory_order_relaxed);
     }
 
-    inline Handle load_atlas(TextureAtlas& atlas, int atlasIndex = 0) {
+    inline Handle load_atlas(const TextureAtlas& atlas, int atlasIndex = 0) {
         atlasmanager::ensure_uploaded(atlas);
         return make_handle(atlasIndex, 0);
     }

--- a/AlmondShell/include/aspriteregistry.hpp
+++ b/AlmondShell/include/aspriteregistry.hpp
@@ -28,12 +28,14 @@
 #include "aspritehandle.hpp"
 #include "aspritepool.hpp"
 
-#include <unordered_map>
-#include <tuple>
+#include <atomic>
+#include <iostream>
 #include <optional>
+#include <shared_mutex>
 #include <string>
 #include <string_view>
-#include <iostream>
+#include <tuple>
+#include <unordered_map>
 
 namespace almondnamespace {
 
@@ -79,8 +81,8 @@ namespace almondnamespace {
             TransparentEqual
         > sprites;
 
-        // Optional pointer to the associated atlas
-        const TextureAtlas* atlas_ptr = nullptr;
+        mutable std::shared_mutex mutex;
+        std::atomic<const TextureAtlas*> atlas_ptr{ nullptr };
 
         void add(std::string_view name, SpriteHandle handle, float u0, float v0, float width, float height, float pivotX = 0.f, float pivotY = 0.f) {
             if (!handle.is_valid() || !spritepool::is_alive(handle)) {
@@ -89,6 +91,8 @@ namespace almondnamespace {
             }
 
             // Check if the handle is already used for a different sprite to avoid duplicates
+            std::unique_lock lock(mutex);
+
             for (const auto& [existingName, entry] : sprites) {
                 const SpriteHandle& existingHandle = std::get<0>(entry);
                 if (existingHandle == handle && existingName != name) {
@@ -109,11 +113,13 @@ namespace almondnamespace {
 
         [[nodiscard]]
         std::optional<Entry> get(std::string_view name) const noexcept {
+            std::shared_lock lock(mutex);
             auto it = sprites.find(name); // Uses transparent lookup
             return (it != sprites.end()) ? std::optional{ it->second } : std::nullopt;
         }
 
         bool remove(std::string_view name) {
+            std::unique_lock lock(mutex);
             auto it = sprites.find(name);
             if (it != sprites.end()) {
                 sprites.erase(it);
@@ -123,6 +129,7 @@ namespace almondnamespace {
         }
 
         bool remove_if_invalid(std::string_view name) {
+            std::unique_lock lock(mutex);
             auto it = sprites.find(name);
             if (it == sprites.end())
                 return false;
@@ -136,6 +143,7 @@ namespace almondnamespace {
         }
 
         void cleanup_dead() {
+            std::unique_lock lock(mutex);
             for (auto it = sprites.begin(); it != sprites.end();) {
                 if (!spritepool::is_alive(std::get<0>(it->second)))
                     it = sprites.erase(it);
@@ -145,7 +153,16 @@ namespace almondnamespace {
         }
 
         void clear() noexcept {
+            std::unique_lock lock(mutex);
             sprites.clear();
+        }
+
+        void set_atlas(const TextureAtlas* atlas) noexcept {
+            atlas_ptr.store(atlas, std::memory_order_release);
+        }
+
+        [[nodiscard]] const TextureAtlas* get_atlas() const noexcept {
+            return atlas_ptr.load(std::memory_order_acquire);
         }
     };
 

--- a/AlmondShell/include/atetrislike.hpp
+++ b/AlmondShell/include/atetrislike.hpp
@@ -199,7 +199,7 @@ namespace almondnamespace::tetris
 
         // Register sprite handle in registry
         registry.add("tetris_block", handle, 0.f, 0.f, 1.f, 1.f, 0.f, 0.f);
-        registry.atlas_ptr = &atlas;
+        registry.set_atlas(&atlas);
 
         return true;
     }
@@ -268,7 +268,7 @@ namespace almondnamespace::tetris
             float ch = float(ctx->get_height_safe()) / GRID_H;
 
             auto entry = registry.get("tetris_block");
-            if (entry && registry.atlas_ptr)
+            if (entry && registry.get_atlas())
             {
                 auto& [handle, u0, v0, u1, v1, px, py] = *entry;
 


### PR DESCRIPTION
## Summary
- Harden atlas registry and atlas manager with shared mutexes, atomic atlas references, and backend-aware upload queues.
- Ensure every graphics context binds `add_atlas` through a common thunk, registers upload callbacks, and processes pending uploads immediately.
- Allow atlas loaders across backends to accept `const TextureAtlas&` and use the shared `ensure_uploaded` path while updating menu/tetris helpers to the new API.

## Testing
- Not run (build requires platform-specific dependencies).


------
https://chatgpt.com/codex/tasks/task_e_68d46649f4808333a6761dfe25c83dd0