### PR TITLE
Wire multiplexer windows to centralized contexts

### DIFF
--- a/AlmondShell/include/acontextmultiplexer.hpp
+++ b/AlmondShell/include/acontextmultiplexer.hpp
@@ -120,7 +120,7 @@ namespace almondnamespace::core
         void EnqueueRenderCommand(HWND hwnd, MultiContextManager::RenderCommand cmd);
 
         // ---- Context API ----
-        static void SetCurrent(std::shared_ptr<core::Context> ctx);
+        static void SetCurrent(const std::shared_ptr<core::Context>& ctx);
         static std::shared_ptr<core::Context> GetCurrent();
 
         // ---- Windows Message Handling ----
@@ -146,13 +146,14 @@ namespace almondnamespace::core
 
         // ---- Internals ----
         void RenderLoop(WindowData& win);
+        std::shared_ptr<core::Context> acquireContext(ContextType type);
         void SetupPixelFormat(HDC hdc);
         HGLRC CreateSharedGLContext(HDC hdc);
         //bool ProcessBackend(ContextType type);
         int get_title_bar_thickness(const HWND window_handle);
 
         // ---- Static Shared ----
-        inline static std::shared_ptr<core::Context> currentContext;
+        inline static thread_local std::shared_ptr<core::Context> currentContext;
     };
 
     // ======================================================


### PR DESCRIPTION
## Summary
- ensure the multiplexer bootstraps backend contexts from the centralized registry before creating windows
- reuse and clone registered backend contexts for new windows and threads instead of allocating ad-hoc instances
- track the active per-thread context in the render loop so each window retains its state while following engine direction

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d46f7be3548333b6af4b60d8611085