### PR TITLE
Fix multiplexer context wiring

### DIFF
--- a/AlmondShell/include/acontext.hpp
+++ b/AlmondShell/include/acontext.hpp
@@ -193,6 +193,7 @@ namespace almondnamespace::core
     extern BackendMap g_backends;
 
     void InitializeAllContexts();
+    std::shared_ptr<Context> CloneContext(const Context& prototype);
     void AddContextForBackend(ContextType type, std::shared_ptr<Context> context);
     bool ProcessAllContexts();
 


### PR DESCRIPTION
## Summary
- add a reusable Context clone helper so multiplexer windows inherit the backend function table
- initialize the multiplexer with the shared backend prototypes and assign widths/resize callbacks when wiring windows
- recycle context instances when windows close so new windows pick up the proper state tentacles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d46f7be3548333b6af4b60d8611085