### PR TITLE
Fix OpenGL sprite V orientation

### DIFF
--- a/AlmondShell/include/aopenglrenderer.hpp
+++ b/AlmondShell/include/aopenglrenderer.hpp
@@ -190,11 +190,12 @@ namespace almondnamespace::openglrenderer
 
         const auto& entry = atlas->entries[localIdx];
 
-        // Flip V coords for OpenGL (bottom-left origin)
         float u0 = entry.region.u1;
         float u1 = entry.region.u2;
-        float v0 = 1.0f - entry.region.v1; 
-        float v1 = 1.0f - entry.region.v2; 
+        // The image loader already flips images vertically, so provide a
+        // reversed V span here to avoid a second inversion on the GPU.
+        float v0 = entry.region.v2;
+        float v1 = entry.region.v1;
 
         float du = u1 - u0;
         float dv = v1 - v0;

--- a/AlmondShell/include/aopengltextures.hpp
+++ b/AlmondShell/include/aopengltextures.hpp
@@ -393,9 +393,11 @@ namespace almondnamespace::opengltextures
             << ", u2=" << entry.region.u2 << ", v2=" << entry.region.v2 << '\n';
 
         const float u0 = entry.region.u1;
-        const float v0 = entry.region.v1;
         const float du = entry.region.u2 - entry.region.u1;
-        const float dv = entry.region.v2 - entry.region.v1;
+        // Image loader already provides vertically flipped data, so feed the
+        // shader a reversed V span to avoid a second flip on the GPU side.
+        const float v0 = entry.region.v2;
+        const float dv = entry.region.v1 - entry.region.v2;
 
         std::cerr << "[DrawSprite] UVs: u0=" << u0 << ", du=" << du << "\n";
         std::cerr << "[DrawSprite] UVs: v0=" << v0 << ", dv=" << dv << "\n";


### PR DESCRIPTION
## Summary
- feed OpenGL shaders V coordinates in reverse to avoid double flipping when the image loader already flips vertically
- update the legacy OpenGL renderer helper to use the same reversed V span

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d47ea122888333beb21227e7217694