### PR TITLE
Ensure atlas entry access is thread safe

### DIFF
--- a/AlmondShell/include/aatlasmanager.hpp
+++ b/AlmondShell/include/aatlasmanager.hpp
@@ -196,18 +196,7 @@ namespace almondnamespace::atlasmanager
                 return std::nullopt;
             }
             auto& added = *addedOpt;
-
-            int localIndex = -1;
-            for (int i = 0; i < static_cast<int>(sharedAtlas.entries.size()); ++i) {
-                if (sharedAtlas.entries[i].name == name) {
-                    localIndex = i;
-                    break;
-                }
-            }
-            if (localIndex < 0) {
-                std::cerr << "[AtlasRegistrar] Could not find local sprite index for '" << name << "'\n";
-                return std::nullopt;
-            }
+            const int localIndex = added.index;
 
             auto allocated = allocate();
             if (!allocated.is_valid()) {

--- a/AlmondShell/include/aatlastexture.hpp
+++ b/AlmondShell/include/aatlastexture.hpp
@@ -35,6 +35,8 @@
 #include <iostream>
 #include <stdexcept>
 #include <algorithm>
+#include <mutex>
+#include <shared_mutex>
 #include <unordered_map>
 
 namespace almondnamespace 
@@ -91,6 +93,25 @@ namespace almondnamespace
 
         std::vector<AtlasEntry> entries;
 
+        [[nodiscard]] size_t entry_count() const noexcept
+        {
+            std::shared_lock<std::shared_mutex> lock(entriesMutex);
+            return entries.size();
+        }
+
+        [[nodiscard]] bool try_get_entry_info(int index, AtlasRegion& outRegion, std::string* outName = nullptr) const
+        {
+            std::shared_lock<std::shared_mutex> lock(entriesMutex);
+            if (index < 0 || index >= static_cast<int>(entries.size()))
+                return false;
+
+            const auto& entry = entries[static_cast<size_t>(index)];
+            outRegion = entry.region;
+            if (outName)
+                *outName = entry.name;
+            return true;
+        }
+
         static TextureAtlas create(const AtlasConfig& config) 
         {
             TextureAtlas atlas;
@@ -117,6 +138,8 @@ namespace almondnamespace
                 std::cerr << "[Atlas] Rejected empty texture '" << id << "'\n";
                 return std::nullopt;
             }
+
+            std::unique_lock<std::shared_mutex> lock(entriesMutex);
 
             if (lookup.contains(id)) {
                 std::cerr << "[Atlas] Duplicate ID: '" << id << "'\n";
@@ -180,9 +203,11 @@ namespace almondnamespace
             return entry;
         }
 
-		/// Adds a slice entry without new pixel data, just references existing pixels.
+                /// Adds a slice entry without new pixel data, just references existing pixels.
         std::optional<AtlasEntry> add_slice_entry(const std::string& id, int x, int y, int w, int h)
         {
+            std::unique_lock<std::shared_mutex> lock(entriesMutex);
+
             if (w <= 0 || h <= 0) {
                 std::cerr << "[Atlas] Invalid slice size for '" << id << "'\n";
                 return std::nullopt;
@@ -231,11 +256,13 @@ namespace almondnamespace
         }
 
         std::optional<AtlasRegion> get_region(const std::string& id) const {
+            std::shared_lock<std::shared_mutex> lock(entriesMutex);
             auto it = lookup.find(id);
             return (it != lookup.end()) ? std::optional{ it->second } : std::nullopt;
         }
 
         void rebuild_pixels() const {
+            std::shared_lock<std::shared_mutex> lock(entriesMutex);
             const size_t size = static_cast<size_t>(width) * height * 4;
             if (pixel_data.size() != size)
                 pixel_data.resize(size);
@@ -255,6 +282,7 @@ namespace almondnamespace
         }
 
     private:
+        mutable std::shared_mutex entriesMutex;
         std::unordered_map<std::string, AtlasRegion> lookup;
         std::vector<std::vector<bool>> occupancy;
 

--- a/AlmondShell/include/aopengltextures.hpp
+++ b/AlmondShell/include/aopengltextures.hpp
@@ -276,14 +276,14 @@ namespace almondnamespace::opengltextures
             .pixels = std::move(rgba.pixels)
         };
 
-        if (!atlas.add_entry(id, texture)) {
+        auto addedOpt = atlas.add_entry(id, texture);
+        if (!addedOpt) {
             throw std::runtime_error("atlas_add_texture: Failed to add texture: " + id);
         }
 
         atlasmanager::ensure_uploaded(atlas);
 
-        int localIdx = static_cast<int>(atlas.entries.size() - 1);
-        return make_handle(0, localIdx);
+        return make_handle(0, addedOpt->index);
     }
 
     inline uint32_t upload_texture(const uint8_t* pixels, int width, int height) 
@@ -339,7 +339,9 @@ namespace almondnamespace::opengltextures
             std::cerr << "[DrawSprite] Null atlas pointer at index: " << atlasIdx << '\n';
             return;
         }
-        if (localIdx < 0 || localIdx >= int(atlas->entries.size())) {
+        AtlasRegion region{};
+        std::string spriteName;
+        if (!atlas->try_get_entry_info(localIdx, region, &spriteName)) {
             std::cerr << "[DrawSprite] Sprite index out of bounds: " << localIdx << '\n';
             return;
         }
@@ -347,7 +349,7 @@ namespace almondnamespace::opengltextures
         std::cerr << "[DrawSprite] Using atlas index = " << atlasIdx
             << ", atlas name = '" << atlas->name << "'"
             << ", local sprite index = " << localIdx
-            << ", sprite name = '" << atlas->entries[localIdx].name << "'\n";
+            << ", sprite name = '" << spriteName << "'\n";
 
         std::cerr << "[DrawSprite] Pointer key: " << atlas
             << ", Atlas name: " << atlas->name << "\n";
@@ -386,18 +388,16 @@ namespace almondnamespace::opengltextures
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-        const auto& entry = atlas->entries[localIdx];
-
         std::cerr << "[DrawSprite] RAW region: "
-            << "u1=" << entry.region.u1 << ", v1=" << entry.region.v1
-            << ", u2=" << entry.region.u2 << ", v2=" << entry.region.v2 << '\n';
+            << "u1=" << region.u1 << ", v1=" << region.v1
+            << ", u2=" << region.u2 << ", v2=" << region.v2 << '\n';
 
-        const float u0 = entry.region.u1;
-        const float du = entry.region.u2 - entry.region.u1;
+        const float u0 = region.u1;
+        const float du = region.u2 - region.u1;
         // Image loader already provides vertically flipped data, so feed the
         // shader a reversed V span to avoid a second flip on the GPU side.
-        const float v0 = entry.region.v2;
-        const float dv = entry.region.v1 - entry.region.v2;
+        const float v0 = region.v2;
+        const float dv = region.v1 - region.v2;
 
         std::cerr << "[DrawSprite] UVs: u0=" << u0 << ", du=" << du << "\n";
         std::cerr << "[DrawSprite] UVs: v0=" << v0 << ", dv=" << dv << "\n";
@@ -415,18 +415,18 @@ namespace almondnamespace::opengltextures
         float ndc_h = (height / float(h)) * 2.f;
 
 #if defined(DEBUG_TEXTURE_RENDERING_VERY_VERBOSE)
-        std::cerr << "[DrawSprite] Atlas entries count: " << atlas->entries.size() << "\n";
+        std::cerr << "[DrawSprite] Atlas entries count: " << atlas->entry_count() << "\n";
         std::cerr << "[DrawSprite] Requested sprite index: " << localIdx << "\n";
 
         if (y < 0) {
             std::cerr << "[Warning] Negative y coordinate: " << y << '\n';
         }
 
-        std::cerr << "[DrawSprite] Using region for '" << entry.name << "': "
-            << "u1=" << entry.region.u1 << ", v1=" << entry.region.v1
-            << ", u2=" << entry.region.u2 << ", v2=" << entry.region.v2
-            << ", x=" << entry.region.x << ", y=" << entry.region.y
-            << ", w=" << entry.region.width << ", h=" << entry.region.height << '\n';
+        std::cerr << "[DrawSprite] Using region for '" << spriteName << "': "
+            << "u1=" << region.u1 << ", v1=" << region.v1
+            << ", u2=" << region.u2 << ", v2=" << region.v2
+            << ", x=" << region.x << ", y=" << region.y
+            << ", w=" << region.width << ", h=" << region.height << '\n';
 #endif
 
         std::cerr << "uUVRegionLoc=" << backend.glState.uUVRegionLoc << '\n';
@@ -447,7 +447,7 @@ namespace almondnamespace::opengltextures
 
 #if defined(DEBUG_TEXTURE_RENDERING_VERY_VERBOSE)
         std::cerr << "[DrawSprite] Atlas '" << atlas->name
-            << "' Sprite '" << entry.name
+            << "' Sprite '" << spriteName
             << "' AtlasIdx=" << atlasIdx
             << " SpriteIdx=" << localIdx << '\n';
 #endif

--- a/AlmondShell/include/araylibrenderer.hpp
+++ b/AlmondShell/include/araylibrenderer.hpp
@@ -93,12 +93,13 @@ namespace almondnamespace::raylibcontext
             return;
         }
 
-        if (localIdx < 0 || localIdx >= static_cast<int>(atlas->entries.size())) {
+        AtlasRegion region{};
+        if (!atlas->try_get_entry_info(localIdx, region)) {
             std::cerr << "[Raylib_DrawSprite] Sprite index out of bounds: " << localIdx << '\n';
             return;
         }
 
-       almondnamespace::raylibtextures::ensure_uploaded(*atlas);
+        almondnamespace::raylibtextures::ensure_uploaded(*atlas);
 
         auto texIt = almondnamespace::raylibtextures::raylib_gpu_atlases.find(atlas);
         if (texIt == almondnamespace::raylibtextures::raylib_gpu_atlases.end() || texIt->second.texture.id == 0) {
@@ -107,18 +108,16 @@ namespace almondnamespace::raylibcontext
         }
 
         const Texture2D& texture = texIt->second.texture;
-        const auto& entry = atlas->entries[localIdx];
-
         Rect srcRect{
-            static_cast<float>(entry.region.x),
-            static_cast<float>(entry.region.y),
-            static_cast<float>(entry.region.width),
-            static_cast<float>(entry.region.height)
+            static_cast<float>(region.x),
+            static_cast<float>(region.y),
+            static_cast<float>(region.width),
+            static_cast<float>(region.height)
         };
 
         // If width/height <= 0, use native sprite size
-        float drawWidth = (width > 0.f) ? width : static_cast<float>(entry.region.width);
-        float drawHeight = (height > 0.f) ? height : static_cast<float>(entry.region.height);
+        float drawWidth = (width > 0.f) ? width : static_cast<float>(region.width);
+        float drawHeight = (height > 0.f) ? height : static_cast<float>(region.height);
 
         Rect destRect{
             x,

--- a/AlmondShell/include/araylibtextures.hpp
+++ b/AlmondShell/include/araylibtextures.hpp
@@ -214,14 +214,14 @@ namespace almondnamespace::raylibtextures
             .pixels = std::move(rgba.pixels)
         };
 
-        if (!atlas.add_entry(id, texture)) {
+        auto addedOpt = atlas.add_entry(id, texture);
+        if (!addedOpt) {
             throw std::runtime_error("atlas_add_texture: Failed to add texture: " + id);
         }
 
         atlasmanager::ensure_uploaded(atlas);
 
-        int localIdx = static_cast<int>(atlas.entries.size() - 1);
-        return make_handle(0, localIdx);
+        return make_handle(0, addedOpt->index);
     }
 
 } // namespace almondnamespace::raylibcontext

--- a/AlmondShell/include/asdltextures.hpp
+++ b/AlmondShell/include/asdltextures.hpp
@@ -210,14 +210,14 @@ namespace almondnamespace::sdlcontext
             .pixels = std::move(rgba.pixels)
         };
 
-        if (!atlas.add_entry(id, texture)) {
+        auto addedOpt = atlas.add_entry(id, texture);
+        if (!addedOpt) {
             throw std::runtime_error("atlas_add_texture: Failed to add: " + id);
         }
 
         atlasmanager::ensure_uploaded(atlas);
 
-        int localIdx = static_cast<int>(atlas.entries.size() - 1);
-        return make_handle(0, localIdx);
+        return make_handle(0, addedOpt->index);
     }
 
     inline void clear_gpu_atlases() noexcept 
@@ -263,7 +263,8 @@ namespace almondnamespace::sdlcontext
             std::cerr << "[SDL_DrawSprite] Null atlas pointer at index: " << atlasIdx << '\n';
             return;
         }
-        if (localIdx < 0 || localIdx >= int(atlas->entries.size())) {
+        AtlasRegion region{};
+        if (!atlas->try_get_entry_info(localIdx, region)) {
             std::cerr << "[SDL_DrawSprite] Sprite index out of bounds: " << localIdx << '\n';
             return;
         }
@@ -284,7 +285,6 @@ namespace almondnamespace::sdlcontext
             return;
         }
 
-        const auto& entry = atlas->entries[localIdx];
         SDL_FRect dstRect{
             static_cast<float>(x),
             static_cast<float>(y),
@@ -293,10 +293,10 @@ namespace almondnamespace::sdlcontext
         };
 
         SDL_FRect srcRect{
-            static_cast<float>(entry.region.x),
-            static_cast<float>(entry.region.y),
-            static_cast<float>(entry.region.width),
-            static_cast<float>(entry.region.height)
+            static_cast<float>(region.x),
+            static_cast<float>(region.y),
+            static_cast<float>(region.width),
+            static_cast<float>(region.height)
         };
 
 

--- a/AlmondShell/include/asfmltextures.hpp
+++ b/AlmondShell/include/asfmltextures.hpp
@@ -183,14 +183,14 @@ namespace almondnamespace::sfmlcontext
             .pixels = std::move(rgba.pixels)
         };
 
-        if (!atlas.add_entry(id, texture)) {
+        auto addedOpt = atlas.add_entry(id, texture);
+        if (!addedOpt) {
             throw std::runtime_error("atlas_add_texture: Failed to add: " + id);
         }
 
         atlasmanager::ensure_uploaded(atlas);
 
-        int localIdx = static_cast<int>(atlas.entries.size() - 1);
-        return make_handle(0, localIdx);
+        return make_handle(0, addedOpt->index);
     }
 
 
@@ -222,7 +222,8 @@ namespace almondnamespace::sfmlcontext
             return;
         }
 
-        if (localIdx < 0 || localIdx >= int(atlas->entries.size()))
+        AtlasRegion region{};
+        if (!atlas->try_get_entry_info(localIdx, region))
         {
             std::cerr << "[SFML_DrawSprite] Sprite index out of bounds: " << localIdx << '\n';
             return;
@@ -238,15 +239,14 @@ namespace almondnamespace::sfmlcontext
         }
 
         const auto& gpu = it->second;
-        const auto& entry = atlas->entries[localIdx];
 
         // SFML 3.x requires constructing sprite with texture — no default ctor
         sf::Sprite sprite(gpu.texture);
 
         // sf::IntRect doesn't accept unsigned types directly; convert explicitly
         sf::IntRect rect(
-            sf::Vector2i(static_cast<int>(entry.region.x), static_cast<int>(entry.region.y)),
-            sf::Vector2i(static_cast<int>(entry.region.width), static_cast<int>(entry.region.height))
+            sf::Vector2i(static_cast<int>(region.x), static_cast<int>(region.y)),
+            sf::Vector2i(static_cast<int>(region.width), static_cast<int>(region.height))
         );
 
         sprite.setTextureRect(rect);
@@ -254,8 +254,8 @@ namespace almondnamespace::sfmlcontext
 
         if (width > 0.f && height > 0.f)
         {
-            float scaleX = width / float(entry.region.width);
-            float scaleY = height / float(entry.region.height);
+            float scaleX = width / float(region.width);
+            float scaleY = height / float(region.height);
             sprite.setScale(sf::Vector2f(scaleX, scaleY));
         }
 


### PR DESCRIPTION
## Summary
- guard `TextureAtlas` entry metadata with a shared mutex and expose safe accessors
- update SDL, SFML, OpenGL, and Raylib sprite drawing to use the safe accessors instead of raw `entries`
- rely on the entry index returned by `add_entry` rather than the current entry count in atlas helpers

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4883fb1cc83339eb814c3b0ae6c13