### PR TITLE
Refine multi-context runtime management

### DIFF
--- a/AlmondShell/include/acontext.hpp
+++ b/AlmondShell/include/acontext.hpp
@@ -44,6 +44,11 @@
 #include <mutex>
 #include <queue>
 
+namespace almondnamespace::state
+{
+    struct ContextState;
+}
+
 namespace almondnamespace::core
 {
     struct WindowData; // forward declaration
@@ -107,6 +112,7 @@ namespace almondnamespace::core
         AlmondAtomicFunction<uint32_t(TextureAtlas&, std::string, const ImageData&)> add_texture;
         AlmondAtomicFunction<uint32_t(const TextureAtlas&)> add_atlas;
         std::function<void(int, int)> onResize;
+        std::weak_ptr<state::ContextState> state;
 
         Context() = default;
 
@@ -175,6 +181,14 @@ namespace almondnamespace::core
 
         inline int add_model_safe(const char* name, const char* path) const noexcept {
             return add_model ? add_model(name, path) : -1;
+        }
+
+        inline void attach_state(const std::shared_ptr<state::ContextState>& runtimeState) noexcept {
+            state = runtimeState;
+        }
+
+        inline std::shared_ptr<state::ContextState> get_state() const noexcept {
+            return state.lock();
         }
     };
 

--- a/AlmondShell/include/acontextstate.hpp
+++ b/AlmondShell/include/acontextstate.hpp
@@ -46,13 +46,17 @@
 #include "asoftrenderer_state.hpp"
 #endif
 
-#include <memory>  
-#include <atomic>  
-#include <cstdint>  
+#include <memory>
+#include <atomic>
+#include <cstdint>
+#include <thread>
+#include <stdexcept>
+#include <utility>
 
 // Forward declarations for subsystems, no ownership illusions
-namespace almondnamespace::contextwindow { struct WindowContext; }  
-namespace almondnamespace::input { struct Input; }  
+namespace almondnamespace::contextwindow { struct WindowContext; }
+namespace almondnamespace::input { struct Input; }
+namespace almondnamespace::core { struct Context; struct WindowData; struct CommandQueue; }
 //namespace almondnamespace::vr { struct VRSystem; }  
 //namespace almondnamespace::renderer { struct Renderer; }  
 //namespace almondnamespace::audio { struct AudioSystem; }  
@@ -92,44 +96,73 @@ namespace almondnamespace::state
 #endif
 
     struct ContextState final // ContextState encapsulates the state of the context
-    {  
-        // Subsystems: injected, no ownership illusions.  
-        std::shared_ptr<contextwindow::WindowContext> window;  
-        std::shared_ptr<input::Input> input;  
-        //std::shared_ptr<vr::VRSystem> vr;  
-        //std::shared_ptr<renderer::Renderer> renderer;  
-        //std::shared_ptr<audio::AudioSystem> audio;  
+    {
+        // Subsystems: injected, no ownership illusions.
+        std::shared_ptr<contextwindow::WindowContext> window;
+        std::shared_ptr<input::Input> input;
+        //std::shared_ptr<vr::VRSystem> vr;
+        //std::shared_ptr<renderer::Renderer> renderer;
+        //std::shared_ptr<audio::AudioSystem> audio;
 
-        // Engine control  
-        std::atomic<bool> isRunning{ true };  
-        uint64_t frameCount = 0;  
+        // Engine control
+        std::atomic<bool> isRunning{ true };
+        uint64_t frameCount = 0;
 
-        // Constructor  
-        ContextState(  
-            std::shared_ptr<contextwindow::WindowContext> win,  
-            std::shared_ptr<input::Input> in  
-            //std::shared_ptr<vr::VRSystem> vrSystem = nullptr,  
-            //std::shared_ptr<renderer::Renderer> render = nullptr,  
-            //std::shared_ptr<audio::AudioSystem> audioSys = nullptr  
-        )  
-            : window(std::move(win)),  
-            input(std::move(in))  
-            //vr(std::move(vrSystem)),  
-            //renderer(std::move(render)),  
-            //audio(std::move(audioSys))  
-        {  
-        }  
+        std::shared_ptr<core::Context> context;
+        core::WindowData* windowData = nullptr;
+        core::CommandQueue* commandQueue = nullptr;
+        std::thread::id owningThread{};
 
-        //void update()  
-        //{  
-        //    if (window) window->pump_events();  
-        //    if (input) input->poll(*window);  
-        //    if (vr) vr->update();  
-        //    if (audio) audio->update();  
+        // Constructor
+        ContextState() = default;
 
-        //    ++frameCount;  
-        //}  
+        ContextState(
+            std::shared_ptr<contextwindow::WindowContext> win,
+            std::shared_ptr<input::Input> in
+        )
+            : window(std::move(win)),
+            input(std::move(in))
+        {
+        }
 
-        void stop() noexcept { isRunning = false; }  
-    };  
+        //void update()
+        //{
+        //    if (window) window->pump_events();
+        //    if (input) input->poll(*window);
+        //    if (vr) vr->update();
+        //    if (audio) audio->update();
+
+        //    ++frameCount;
+        //}
+
+        void stop() noexcept { isRunning = false; }
+
+        [[nodiscard]] bool is_running() const noexcept { return isRunning.load(std::memory_order_acquire); }
+
+        void attach_runtime(std::shared_ptr<core::Context> ctx,
+            core::WindowData* windowPtr,
+            core::CommandQueue* queuePtr)
+        {
+            context = std::move(ctx);
+            windowData = windowPtr;
+            commandQueue = queuePtr;
+        }
+
+        [[nodiscard]] core::CommandQueue& command_queue() const
+        {
+            if (!commandQueue)
+                throw std::runtime_error("ContextState missing command queue");
+            return *commandQueue;
+        }
+
+        void bind_to_current_thread() noexcept
+        {
+            owningThread = std::this_thread::get_id();
+        }
+
+        [[nodiscard]] bool is_thread_owner() const noexcept
+        {
+            return owningThread == std::this_thread::get_id();
+        }
+    };
 }

--- a/AlmondShell/include/awindowdata.hpp
+++ b/AlmondShell/include/awindowdata.hpp
@@ -7,10 +7,19 @@
 #include "acontexttype.hpp"  // for ContextType
 #include "acommandqueue.hpp" // for CommandQueue
 
-namespace almondnamespace::core 
+namespace almondnamespace::core
 {
     struct Context; // forward declaration
     class MultiContextManager; // Forward declare MultiContextManager for ResizeCallback
+}
+
+namespace almondnamespace::state
+{
+    struct ContextState;
+}
+
+namespace almondnamespace::core
+{
 
     struct WindowData
     {
@@ -30,6 +39,7 @@ namespace almondnamespace::core
         ResizeCallback onResize;
 
         CommandQueue commandQueue;
+        std::shared_ptr<state::ContextState> runtimeState;
 
         WindowData() = default;
         WindowData(HWND h, HDC dc, HGLRC ctx, bool shared, almondnamespace::core::ContextType t)

--- a/AlmondShell/src/acontext.cpp
+++ b/AlmondShell/src/acontext.cpp
@@ -358,6 +358,7 @@ namespace almondnamespace::core {
         clone->hdc = nullptr;
         clone->hglrc = nullptr;
         clone->windowData = nullptr;
+        clone->state.reset();
 
         return clone;
     }


### PR DESCRIPTION
## Summary
- attach per-window ContextState instances to WindowData/Context so each render thread has explicit runtime state
- update ContextManager with thread-local storage and an RAII scope helper for setting the active ContextState
- refactor MultiContextManager::RenderLoop to use the shared runtime state, manage backend setup/cleanup, and ensure orderly shutdown

## Testing
- cmake -S AlmondShell -B build
- cmake --build build *(fails: missing optional dependency `asio.hpp` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4c83edfd88333bae8401906ccd48d