### PR TITLE
Fix menu button ordering

### DIFF
--- a/AlmondShell/include/aguimenu.hpp
+++ b/AlmondShell/include/aguimenu.hpp
@@ -214,8 +214,14 @@ namespace almondnamespace::menu
             slicePairs.reserve(buttonNames.size());
 
             for (size_t idx = 0; idx < buttonNames.size(); ++idx) {
-                const int row = static_cast<int>(idx) / ExpectedColumns;
-                const int col = static_cast<int>(idx) % ExpectedColumns;
+                const int rowFromTop = static_cast<int>(idx) / ExpectedColumns;
+                const int colFromLeft = static_cast<int>(idx) % ExpectedColumns;
+
+                // The sprite sheet is authored starting at the bottom-right corner,
+                // so flip both axes when slicing so logical index 0 maps to the
+                // top-left button in the menu grid.
+                const int row = ExpectedRowsPerHalf - 1 - rowFromTop;
+                const int col = ExpectedColumns - 1 - colFromLeft;
 
                 const int normalX = col * spriteW;
                 const int normalY = row * spriteH;


### PR DESCRIPTION
## Summary
- flip the inferred row and column indices when slicing menu button sprites so logical button order matches the intended layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4f31ee52483338cdd1b45c98e3a0f