### PR TITLE
Fix menu button column ordering

### DIFF
--- a/AlmondShell/include/aguimenu.hpp
+++ b/AlmondShell/include/aguimenu.hpp
@@ -217,11 +217,12 @@ namespace almondnamespace::menu
                 const int rowFromTop = static_cast<int>(idx) / ExpectedColumns;
                 const int colFromLeft = static_cast<int>(idx) % ExpectedColumns;
 
-                // The sprite sheet is authored starting at the bottom-right corner,
-                // so flip both axes when slicing so logical index 0 maps to the
-                // top-left button in the menu grid.
+                // The sprite sheet is authored starting at the bottom edge, so we
+                // flip the row index to keep logical index 0 at the top-left of the
+                // menu grid while preserving the original left-to-right ordering of
+                // columns.
                 const int row = ExpectedRowsPerHalf - 1 - rowFromTop;
-                const int col = ExpectedColumns - 1 - colFromLeft;
+                const int col = colFromLeft;
 
                 const int normalX = col * spriteW;
                 const int normalY = row * spriteH;


### PR DESCRIPTION
## Summary
- correct the menu sprite slicing so button columns retain their original left-to-right order
- update comments to reflect the sprite sheet orientation without horizontal flipping

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4fde142308333ae5faf1eae8a6398