### PR TITLE
Add scene-based Match3 implementation and menu integration

### DIFF
--- a/AlmondShell/include/amatch3like.hpp
+++ b/AlmondShell/include/amatch3like.hpp
@@ -24,154 +24,211 @@
  // amatch3game.hpp
 #pragma once
 
+#include "ascene.hpp"
+#include "aeventsystem.hpp"
 #include "aplatformpump.hpp"
-#include "arobusttime.hpp"
 #include "acontext.hpp"
 #include "ainput.hpp"
 #include "agamecore.hpp"
 #include "aatlasmanager.hpp"
 #include "aimageloader.hpp"
+#include "aspritepool.hpp"
 
-#include <vector>
-#include <chrono>
-#include <unordered_map>
-#include <string>
+#include <array>
+#include <cmath>
+#include <cstdlib>
 #include <random>
-#include <iostream>
+#include <span>
+#include <string>
+#include <stdexcept>
+#include <tuple>
+#include <utility>
 
 namespace almondnamespace::match3
 {
-    constexpr int GRID_W = 8;
-    constexpr int GRID_H = 8;
-    constexpr int MAX_GEM_TYPE = 5;
+    inline constexpr int GRID_W = 8;
+    inline constexpr int GRID_H = 8;
+    inline constexpr int MAX_GEM_TYPE = 5;
 
     struct GameState {
-        gamecore::grid_t<int> grid;
-        int selectedX = -1, selectedY = -1;
-
-        GameState()
-            : grid(gamecore::make_grid<int>(GRID_W, GRID_H, 0))
-        {
-            std::mt19937_64 rng{ std::random_device{}() };
-            std::uniform_int_distribution<int> dist(0, MAX_GEM_TYPE);
-
-            for (int y = 0; y < GRID_H; ++y)
-                for (int x = 0; x < GRID_W; ++x)
-                    grid[gamecore::idx(GRID_W, x, y)] = dist(rng);
-        }
+        gamecore::grid_t<int> grid{ gamecore::make_grid<int>(GRID_W, GRID_H, 0) };
+        int selectedX = -1;
+        int selectedY = -1;
     };
 
-    inline bool run_match3(std::shared_ptr<core::Context> ctx)
-    {
-        using namespace almondnamespace;
-
-        // === Setup Atlas ===
-        if (!atlasmanager::create_atlas({
-            .name = "match3_atlas",
-            .width = 512,
-            .height = 512,
-            .generate_mipmaps = false }))
+    struct Match3Scene : public scene::Scene {
+        Match3Scene(Logger* L = nullptr, time::Timer* C = nullptr)
+            : Scene(L, C)
         {
-            std::cerr << "[Match3] Failed to create atlas\n";
-            return false;
         }
 
-        auto* registrar = atlasmanager::get_registrar("match3_atlas");
-        if (!registrar)
-        {
-            std::cerr << "[Match3] Missing atlas registrar\n";
-            return false;
+        void load() override {
+            Scene::load();
+            setupSprites();
+            resetBoard();
+            mouseWasDown = false;
         }
 
-        TextureAtlas& atlas = registrar->atlas;
+        bool frame(std::shared_ptr<core::Context> ctx, core::WindowData*) override {
+            if (!ctx) return false;
 
-        // --- Load each gem sprite ---
-        for (int i = 0; i <= MAX_GEM_TYPE; ++i)
-        {
-            auto name = "gem" + std::to_string(i);
-            auto img = a_loadImage("assets/" + name + ".ppm", false);
-            if (img.pixels.empty()) {
-                std::cerr << "[Match3] Failed to load " << name << "\n";
+            input::poll_input();
+            events::pump();
+
+            if (ctx->is_key_held(input::Key::Escape))
                 return false;
+
+            handleMouse(ctx);
+            render(ctx);
+            return true;
+        }
+
+        void unload() override {
+            Scene::unload();
+            gemHandles.fill(SpriteHandle{});
+            mouseWasDown = false;
+        }
+
+    private:
+        std::array<SpriteHandle, MAX_GEM_TYPE + 1> gemHandles{};
+        GameState state{};
+        bool mouseWasDown = false;
+        std::mt19937_64 rng{ std::random_device{}() };
+        std::uniform_int_distribution<int> gemDist{ 0, MAX_GEM_TYPE };
+
+        void setupSprites() {
+            const bool createdAtlas = atlasmanager::create_atlas({
+                .name = "match3_atlas",
+                .width = 512,
+                .height = 512,
+                .generate_mipmaps = false
+                });
+
+            auto* registrar = atlasmanager::get_registrar("match3_atlas");
+            if (!registrar)
+                throw std::runtime_error("[Match3] Missing atlas registrar");
+
+            TextureAtlas& atlas = registrar->atlas;
+            bool registeredSprite = false;
+
+            for (int i = 0; i <= MAX_GEM_TYPE; ++i) {
+                const std::string name = "gem" + std::to_string(i);
+
+                if (auto existing = atlasmanager::registry.get(name)) {
+                    auto handle = std::get<0>(*existing);
+                    if (spritepool::is_alive(handle)) {
+                        gemHandles[i] = handle;
+                        continue;
+                    }
+                }
+
+                auto img = a_loadImage("assets/" + name + ".ppm", false);
+                if (img.pixels.empty())
+                    throw std::runtime_error("[Match3] Failed to load sprite: " + name);
+
+                auto handleOpt = registrar->register_atlas_sprites_by_image(
+                    name, img.pixels, img.width, img.height, atlas);
+                if (!handleOpt || !spritepool::is_alive(*handleOpt))
+                    throw std::runtime_error("[Match3] Failed to register sprite: " + name);
+
+                gemHandles[i] = *handleOpt;
+                registeredSprite = true;
             }
-            if (!registrar->register_atlas_sprites_by_image(name, img.pixels, img.width, img.height, atlas)) {
-                return false;
+
+            if (registeredSprite || createdAtlas) {
+                atlas.rebuild_pixels();
+                atlasmanager::ensure_uploaded(atlas);
             }
         }
 
-        atlas.rebuild_pixels();
-        atlasmanager::ensure_uploaded(atlas);
+        void resetBoard() {
+            if (state.grid.empty())
+                state.grid = gamecore::make_grid<int>(GRID_W, GRID_H, 0);
 
-        auto& atlasVec = atlasmanager::get_atlas_vector();
-        std::span<const TextureAtlas* const> atlasSpan(atlasVec.data(), atlasVec.size());
-
-        // --- Fetch handles from registry ---
-        std::unordered_map<int, SpriteHandle> sprites;
-        for (int i = 0; i <= MAX_GEM_TYPE; ++i) {
-            auto name = "gem" + std::to_string(i);
-            auto opt = atlasmanager::registry.get(name);
-            if (!opt) {
-                std::cerr << "[Match3] Registry missing " << name << "\n";
-                return false;
+            for (int y = 0; y < GRID_H; ++y) {
+                for (int x = 0; x < GRID_W; ++x) {
+                    state.grid[gamecore::idx(GRID_W, x, y)] = gemDist(rng);
+                }
             }
-            sprites[i] = std::get<0>(*opt);
+            state.selectedX = -1;
+            state.selectedY = -1;
         }
 
-        GameState s;
-        bool game_over = false;
-
-        while (!game_over)
-        {
-            platform::pump_events();
-            if (ctx->is_key_down_safe(input::Key::Escape)) break;
-
+        void handleMouse(const std::shared_ptr<core::Context>& ctx) {
             int mx = 0, my = 0;
             ctx->get_mouse_position_safe(mx, my);
+            const bool mouseDown = ctx->is_mouse_button_down_safe(input::MouseButton::MouseLeft);
 
-            if (ctx->is_mouse_button_down_safe(input::MouseButton::MouseLeft))
-            {
-                int x = int(mx / (float(ctx->get_width_safe()) / GRID_W));
-                int y = int(my / (float(ctx->get_height_safe()) / GRID_H));
+            if (mouseDown && !mouseWasDown) {
+                const float cellW = float(ctx->get_width_safe()) / GRID_W;
+                const float cellH = float(ctx->get_height_safe()) / GRID_H;
+                const int gx = static_cast<int>(mx / cellW);
+                const int gy = static_cast<int>(my / cellH);
 
-                if (gamecore::in_bounds(GRID_W, GRID_H, x, y))
-                {
-                    if (s.selectedX == -1) {
-                        s.selectedX = x; s.selectedY = y;
-                    }
-                    else if ((abs(x - s.selectedX) + abs(y - s.selectedY)) == 1) {
-                        std::swap(
-                            s.grid[gamecore::idx(GRID_W, x, y)],
-                            s.grid[gamecore::idx(GRID_W, s.selectedX, s.selectedY)]
-                        );
-                        s.selectedX = -1; s.selectedY = -1;
+                if (gamecore::in_bounds(GRID_W, GRID_H, gx, gy)) {
+                    if (state.selectedX == -1) {
+                        state.selectedX = gx;
+                        state.selectedY = gy;
                     }
                     else {
-                        s.selectedX = x; s.selectedY = y;
+                        const int manhattan = std::abs(gx - state.selectedX) + std::abs(gy - state.selectedY);
+                        if (manhattan == 1) {
+                            std::swap(
+                                state.grid[gamecore::idx(GRID_W, gx, gy)],
+                                state.grid[gamecore::idx(GRID_W, state.selectedX, state.selectedY)]);
+                            state.selectedX = -1;
+                            state.selectedY = -1;
+                        }
+                        else {
+                            state.selectedX = gx;
+                            state.selectedY = gy;
+                        }
                     }
                 }
             }
 
+            mouseWasDown = mouseDown;
+        }
+
+        void render(const std::shared_ptr<core::Context>& ctx) {
             ctx->clear_safe(ctx);
 
-            float cw = float(ctx->get_width_safe()) / GRID_W;
-            float ch = float(ctx->get_height_safe()) / GRID_H;
+            const float cellW = float(ctx->get_width_safe()) / GRID_W;
+            const float cellH = float(ctx->get_height_safe()) / GRID_H;
 
-            for (int y = 0; y < GRID_H; ++y)
-            {
-                for (int x = 0; x < GRID_W; ++x)
-                {
-                    int t = s.grid[gamecore::idx(GRID_W, x, y)];
-                    auto it = sprites.find(t);
-                    if (it != sprites.end() && spritepool::is_alive(it->second))
-                    {
-                        ctx->draw_sprite_safe(it->second, atlasSpan,
-                            x * cw, y * ch, cw, ch);
-                    }
+            auto& atlasVec = atlasmanager::get_atlas_vector();
+            std::span<const TextureAtlas* const> atlasSpan(atlasVec.data(), atlasVec.size());
+
+            for (int y = 0; y < GRID_H; ++y) {
+                for (int x = 0; x < GRID_W; ++x) {
+                    const int type = state.grid[gamecore::idx(GRID_W, x, y)];
+                    if (type < 0 || type > MAX_GEM_TYPE) continue;
+
+                    const auto& handle = gemHandles[type];
+                    if (!spritepool::is_alive(handle)) continue;
+
+                    ctx->draw_sprite_safe(handle, atlasSpan,
+                        x * cellW, y * cellH, cellW, cellH);
                 }
             }
 
             ctx->present_safe();
         }
-        return game_over;
+    };
+
+    inline bool run_match3(std::shared_ptr<core::Context> ctx)
+    {
+        Match3Scene scene;
+        scene.load();
+        auto* window = ctx ? ctx->windowData : nullptr;
+        bool running = true;
+
+        while (running && ctx) {
+            platform::pump_events();
+            running = scene.frame(ctx, window);
+        }
+
+        scene.unload();
+        return running;
     }
 }

--- a/AlmondShell/src/aengine.cpp
+++ b/AlmondShell/src/aengine.cpp
@@ -1966,7 +1966,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
     almondnamespace::core::ShowConsole();
 #endif
 
-    enum class SceneID { Menu, Snake, Tetris, Exit };
+    enum class SceneID { Menu, Snake, Tetris, Match3, Exit };
 
     SceneID g_sceneID = SceneID::Menu;
     std::unique_ptr<almondnamespace::scene::Scene> g_activeScene;
@@ -2048,6 +2048,12 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
                                 g_activeScene->load();
                                 g_sceneID = SceneID::Tetris;
                             }
+                            else if (*choice == almondnamespace::menu::Choice::Bejeweled) {
+                                if (g_activeScene) g_activeScene->unload();
+                                g_activeScene = std::make_unique<almondnamespace::match3::Match3Scene>();
+                                g_activeScene->load();
+                                g_sceneID = SceneID::Match3;
+                            }
                             else if (*choice == almondnamespace::menu::Choice::Exit) {
                                 g_sceneID = SceneID::Exit;
                                 running = false;
@@ -2057,6 +2063,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
                     }
                     case SceneID::Snake:
                     case SceneID::Tetris:
+                    case SceneID::Match3:
                         if (g_activeScene) {
                             ctxRunning = g_activeScene->frame(ctx, win);
                             if (!ctxRunning) {


### PR DESCRIPTION
## Summary
- replace the Match3 mini-game loop with a scene-based implementation that uses the new engine flow
- ensure atlas sprites are created or reused safely and improve input handling for selections
- hook the Bejeweled menu option into the new Match3 scene so it can be launched from the menu

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d648484730833384a57a61e10fe635