### PR TITLE
Fix game rendering queue integration and responsive menu layout

### DIFF
--- a/AlmondShell/include/aguimenu.hpp
+++ b/AlmondShell/include/aguimenu.hpp
@@ -75,11 +75,13 @@ namespace almondnamespace::menu
         bool initialized = false;
 
         std::vector<std::pair<int, int>> cachedPositions; // x,y per item
+        std::vector<std::pair<int, int>> cachedSizes;      // width,height per item
         std::vector<float> colWidths, rowHeights;
         int cachedWidth = -1;
         int cachedHeight = -1;
         int columns = 1;
         int rows = 0;
+        float cachedScale = 1.0f;
 
         static constexpr int ExpectedColumns = 4;
         static constexpr int ExpectedRowsPerHalf = 3;
@@ -107,13 +109,13 @@ namespace almondnamespace::menu
                 maxItemHeight = std::max(maxItemHeight, float(pair.normal.height));
             }
 
-            const float spacing = LayoutSpacing;
+            const float baseSpacing = LayoutSpacing;
             int computedCols = totalItems;
             if (maxItemWidth > 0.f) {
                 const float availableWidth = static_cast<float>(std::max(1, cachedWidth));
-                const float denom = maxItemWidth + spacing;
+                const float denom = maxItemWidth + baseSpacing;
                 if (denom > 0.f) {
-                    computedCols = static_cast<int>(std::floor((availableWidth + spacing) / denom));
+                    computedCols = static_cast<int>(std::floor((availableWidth + baseSpacing) / denom));
                     computedCols = std::clamp(computedCols, 1, totalItems);
                 }
             }
@@ -133,29 +135,50 @@ namespace almondnamespace::menu
                 rowHeights[row] = std::max(rowHeights[row], float(slice.height));
             }
 
-            float totalWidth = spacing * std::max(0, columns - 1);
+            float totalWidth = baseSpacing * std::max(0, columns - 1);
             for (float w : colWidths) totalWidth += w;
-            float totalHeight = spacing * std::max(0, rows - 1);
+            float totalHeight = baseSpacing * std::max(0, rows - 1);
             for (float h : rowHeights) totalHeight += h;
 
-            const float baseX = std::max(0.f, (static_cast<float>(cachedWidth) - totalWidth) * 0.5f);
-            const float baseY = std::max(0.f, (static_cast<float>(cachedHeight) - totalHeight) * 0.5f);
+            const float availW = static_cast<float>(std::max(1, cachedWidth));
+            const float availH = static_cast<float>(std::max(1, cachedHeight));
+            float scaleX = (totalWidth > 0.f) ? (availW / totalWidth) : 1.f;
+            float scaleY = (totalHeight > 0.f) ? (availH / totalHeight) : 1.f;
+            if (!std::isfinite(scaleX)) scaleX = 1.f;
+            if (!std::isfinite(scaleY)) scaleY = 1.f;
+            cachedScale = std::clamp(std::min(scaleX, scaleY), 0.5f, 3.0f);
+
+            const float spacing = baseSpacing * cachedScale;
+            totalWidth = spacing * std::max(0, columns - 1);
+            for (float w : colWidths) totalWidth += w * cachedScale;
+            totalHeight = spacing * std::max(0, rows - 1);
+            for (float h : rowHeights) totalHeight += h * cachedScale;
+
+            const float baseX = std::max(0.f, (availW - totalWidth) * 0.5f);
+            const float baseY = std::max(0.f, (availH - totalHeight) * 0.5f);
 
             cachedPositions.resize(totalItems);
+            cachedSizes.resize(totalItems);
             float yPos = baseY;
             for (int r = 0; r < rows; ++r) {
                 float xPos = baseX;
                 for (int c = 0; c < columns; ++c) {
                     const int idx = r * columns + c;
                     if (idx < totalItems) {
+                        const float itemW = colWidths[c] * cachedScale;
+                        const float itemH = rowHeights[r] * cachedScale;
                         cachedPositions[idx] = {
                             static_cast<int>(std::round(xPos)),
                             static_cast<int>(std::round(yPos))
                         };
+                        cachedSizes[idx] = {
+                            std::max(1, static_cast<int>(std::lround(itemW))),
+                            std::max(1, static_cast<int>(std::lround(itemH)))
+                        };
                     }
-                    xPos += colWidths[c] + spacing;
+                    xPos += colWidths[c] * cachedScale + spacing;
                 }
-                yPos += rowHeights[r] + spacing;
+                yPos += rowHeights[r] * cachedScale + spacing;
             }
         }
 
@@ -262,9 +285,10 @@ namespace almondnamespace::menu
         }
 
         std::optional<Choice> update_and_draw(std::shared_ptr<core::Context> ctx, core::WindowData* win) {
-            if (!initialized) return std::nullopt;
+            if (!initialized || !win) return std::nullopt;
 
-            if (ctx->get_width_safe() != cachedWidth || ctx->get_height_safe() != cachedHeight)
+            if (ctx->get_width_safe() != cachedWidth || ctx->get_height_safe() != cachedHeight ||
+                cachedPositions.size() != slicePairs.size() || cachedSizes.size() != slicePairs.size())
                 recompute_layout(ctx);
 
             input::poll_input();
@@ -279,15 +303,18 @@ namespace almondnamespace::menu
             bool enterPressed = input::keyPressed.test(input::Key::Enter);
 
             const int totalItems = int(slicePairs.size());
-            if (totalItems == 0 || cachedPositions.size() != static_cast<size_t>(totalItems))
+            if (totalItems == 0 ||
+                cachedPositions.size() != static_cast<size_t>(totalItems) ||
+                cachedSizes.size() != static_cast<size_t>(totalItems))
                 return std::nullopt;
 
             int hover = -1;
             for (int i = 0; i < totalItems; ++i) {
                 const auto& slice = slicePairs[i].normal;
                 const auto& pos = cachedPositions[i];
-                if (mx >= pos.first && mx <= pos.first + slice.width &&
-                    my >= pos.second && my <= pos.second + slice.height) {
+                const auto& size = cachedSizes[i];
+                if (mx >= pos.first && mx <= pos.first + size.first &&
+                    my >= pos.second && my <= pos.second + size.second) {
                     hover = i;
                     break;
                 }
@@ -315,20 +342,13 @@ namespace almondnamespace::menu
                 const auto& slice = isHighlighted ? slicePairs[i].hover : slicePairs[i].normal;
                 if (!is_alive(slice.handle)) continue;
                 const auto& pos = cachedPositions[i];
+                const auto& size = cachedSizes[i];
 
-                win->commandQueue.enqueue([handle = slice.handle,
-                    x = pos.first, y = pos.second,
-                    w = slice.width, h = slice.height]() {
-                        // build span fresh on render thread
-                        auto& atlasVecRT = atlasmanager::get_atlas_vector();
-                        std::span<const TextureAtlas* const> atlasSpanRT(atlasVecRT.data(), atlasVecRT.size());
-
-                        almondnamespace::opengltextures::draw_sprite(
-                            handle, atlasSpanRT,
-                            float(x), float(y),
-                            float(w), float(h)
-                        );
-                    });
+                ctx->draw_sprite_safe(slice.handle, atlasSpan,
+                    static_cast<float>(pos.first),
+                    static_cast<float>(pos.second),
+                    static_cast<float>(size.first),
+                    static_cast<float>(size.second));
             }
 
             const bool triggeredByEnter = enterPressed && !prevEnter;
@@ -355,12 +375,14 @@ namespace almondnamespace::menu
             }
             slicePairs.clear();
             cachedPositions.clear();
+            cachedSizes.clear();
             colWidths.clear();
             rowHeights.clear();
             cachedWidth = -1;
             cachedHeight = -1;
             columns = 1;
             rows = 0;
+            cachedScale = 1.0f;
             initialized = false;
         }
     };

--- a/AlmondShell/include/araylibcontext.hpp
+++ b/AlmondShell/include/araylibcontext.hpp
@@ -271,6 +271,8 @@ namespace almondnamespace::raylibcontext
         BeginDrawing();
        // ClearBackground(RED);
         ClearBackground(Color{ r, g, b, 255 });
+
+        queue.drain();
         //DRAWTEXT(TextFormat("Raylib Rendering OK"), 200, 160, 40, BLUE);
 
         EndDrawing();
@@ -288,7 +290,6 @@ namespace almondnamespace::raylibcontext
     // ──────────────────────────────────────────────
     inline void raylib_clear()
     {
-        BeginDrawing();
         ClearBackground(DARKPURPLE);
     }
 

--- a/AlmondShell/include/asdlcontext.hpp
+++ b/AlmondShell/include/asdlcontext.hpp
@@ -266,19 +266,14 @@ namespace almondnamespace::sdlcontext
         SDL_Event e;
         static int i = 0;
         while (SDL_PollEvent(&e)) {
-            if (e.type == SDL_EVENT_QUIT) 
-            {
+            if (e.type == SDL_EVENT_QUIT) {
                 sdlcontext.running = false;
-                std::cout << "SDL Quit Event: " 
-                    << e.type 
-                    << "\n";
-
+                std::cout << "SDL Quit Event: " << e.type << "\n";
             }
             if (keys[SDL_SCANCODE_ESCAPE]) {
                 sdlcontext.running = false; // Exit on Escape key
                 std::cout << "Escape Key Event Count: " << ++i << '\n';
-		    }
-			return true; // Continue processing
+            }
         }
 
         static auto* bgTimer = almondnamespace::time::getTimer("menu", "bg_color");
@@ -294,9 +289,8 @@ namespace almondnamespace::sdlcontext
 
         SDL_SetRenderDrawColor(sdlcontext.renderer, r, g, b, 255);
 
-//        std::cout << "yellow: " << ++i << '\n';
-       // SDL_SetRenderDrawColor(sdlcontext.renderer, 255, 255, 0, 255); //yellow
         SDL_RenderClear(sdlcontext.renderer);
+        queue.drain();
         SDL_RenderPresent(sdlcontext.renderer);
         //while (SDL_PollEvent(&s_sdlstate.sdl_event))
         //{

--- a/AlmondShell/include/asfmlcontext.hpp
+++ b/AlmondShell/include/asfmlcontext.hpp
@@ -334,6 +334,8 @@ namespace almondnamespace::sfmlcontext
 
         sfmlcontext.window->clear(sf::Color(r, g, b));
 
+        queue.drain();
+
         //sfmlcontext.window->clear(sf::Color::Green);
         sfmlcontext.window->display();
         return true;


### PR DESCRIPTION
## Summary
- route context clear/present/draw helpers through the window command queue so game scenes render on the active backend threads
- drain queued render commands in the SDL, SFML, and RayLib backends to keep every context up to date
- recompute the menu layout responsively so buttons stay centered and scale with the window size

## Testing
- Not run (not supported in container)


------
https://chatgpt.com/codex/tasks/task_e_68d663e401ec83338efee347a554faae