### PR TITLE
Ensure raylib and SDL dock to child windows

### DIFF
--- a/AlmondShell/include/araylibcontext.hpp
+++ b/AlmondShell/include/araylibcontext.hpp
@@ -45,6 +45,7 @@
 
 //#include "araylibcontext_win32.hpp"
 
+#include <algorithm>
 #include <stdexcept>
 #include <iostream>
 
@@ -81,7 +82,41 @@ namespace almondnamespace::raylibcontext
         s_raylibstate.onResize = std::move(onResize);
         s_raylibstate.width = w;
         s_raylibstate.height = h;
-        s_raylibstate.parent = parentWnd;
+
+        HWND dockingTarget = nullptr;
+        if (ctx) {
+            if (ctx->windowData && ctx->windowData->hwnd) {
+                dockingTarget = ctx->windowData->hwnd;
+            }
+            else if (ctx->hwnd) {
+                dockingTarget = ctx->hwnd;
+            }
+
+            if (ctx->width > 0 && ctx->height > 0) {
+                s_raylibstate.width = static_cast<unsigned int>(ctx->width);
+                s_raylibstate.height = static_cast<unsigned int>(ctx->height);
+            }
+        }
+
+        if (!dockingTarget && parentWnd) {
+            dockingTarget = parentWnd;
+        }
+
+        if (!dockingTarget && s_raylibstate.parent) {
+            dockingTarget = s_raylibstate.parent;
+        }
+
+        if (dockingTarget) {
+            RECT client{};
+            if (GetClientRect(dockingTarget, &client)) {
+                const auto width = std::max<LONG>(1, client.right - client.left);
+                const auto height = std::max<LONG>(1, client.bottom - client.top);
+                s_raylibstate.width = static_cast<unsigned int>(width);
+                s_raylibstate.height = static_cast<unsigned int>(height);
+            }
+        }
+
+        s_raylibstate.parent = dockingTarget;
 
 
         static bool initialized = false;
@@ -139,7 +174,7 @@ namespace almondnamespace::raylibcontext
         std::cout << "[Raylib] Context: " << s_raylibstate.glContext << "\n";
 
         if (s_raylibstate.parent) {
-            RECT parentRect;
+            RECT parentRect{};
             GetWindowRect(s_raylibstate.parent, &parentRect);
             SetParent(s_raylibstate.hwnd, s_raylibstate.parent);
             ShowWindow(s_raylibstate.hwnd, SW_SHOW);
@@ -149,14 +184,21 @@ namespace almondnamespace::raylibcontext
             style |= WS_CHILD | WS_VISIBLE;
             SetWindowLongPtr(s_raylibstate.hwnd, GWL_STYLE, style);
 
-            SetWindowPos(s_raylibstate.hwnd, nullptr, s_raylibstate.width, 0,
-                s_raylibstate.width,
-                s_raylibstate.height,
+            RECT rc{};
+            GetClientRect(s_raylibstate.parent, &rc);
+            const auto targetWidth = std::max<LONG>(1, rc.right - rc.left);
+            const auto targetHeight = std::max<LONG>(1, rc.bottom - rc.top);
+
+            SetWindowPos(s_raylibstate.hwnd, nullptr, 0, 0,
+                targetWidth,
+                targetHeight,
                 SWP_NOZORDER | SWP_FRAMECHANGED | SWP_SHOWWINDOW);
 
-            RECT rc;
-            GetClientRect(s_raylibstate.parent, &rc);
-            PostMessage(s_raylibstate.parent, WM_SIZE, 0, MAKELPARAM(rc.right - rc.left, rc.bottom - rc.top));
+            if (s_raylibstate.onResize) {
+                s_raylibstate.onResize(static_cast<int>(targetWidth), static_cast<int>(targetHeight));
+            }
+
+            PostMessage(s_raylibstate.parent, WM_SIZE, 0, MAKELPARAM(targetWidth, targetHeight));
         }
 
         s_raylibstate.running = true;


### PR DESCRIPTION
## Summary
- ensure raylib resolves the multiplexer child window as its docking parent and resizes to fill it
- update SDL initialization to embed inside the child window and propagate resize callbacks
- pull host dimensions from the target child window so the backends start with the correct size

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d679b4b05c833384bced6fcb8c6c23