### PR TITLE
Fix multi-context input polling and SFML context blocking

### DIFF
--- a/AlmondShell/include/asfmlcontext.hpp
+++ b/AlmondShell/include/asfmlcontext.hpp
@@ -313,13 +313,23 @@ namespace almondnamespace::sfmlcontext
             return false;
         }
 
-        bool isActiveSFMLcontextwindow = sfmlcontext.window->setActive(); // Activates SFML's render context wrapper
+        if (!sfmlcontext.window->setActive(true)) {
+            std::cerr << "[SFMLRender] Failed to activate SFML window\n";
+            sfmlcontext.running = false;
+            wglMakeCurrent(nullptr, nullptr);
+            return false;
+        }
 
-        if (auto event = sfmlcontext.window->pollEvent()) {
+        while (auto event = sfmlcontext.window->pollEvent()) {
             if (event->is<sf::Event::Closed>()) {
                 sfmlcontext.window->close();
                 sfmlcontext.running = false;
             }
+        }
+        if (!sfmlcontext.running) {
+            sfmlcontext.window->setActive(false);
+            wglMakeCurrent(nullptr, nullptr);
+            return false;
         }
         static auto* bgTimer = almondnamespace::time::getTimer("menu", "bg_color");
         if (!bgTimer)
@@ -336,7 +346,9 @@ namespace almondnamespace::sfmlcontext
 
         //sfmlcontext.window->clear(sf::Color::Green);
         sfmlcontext.window->display();
-        return true;
+        sfmlcontext.window->setActive(false);
+        wglMakeCurrent(nullptr, nullptr);
+        return sfmlcontext.running;
     }
 
     inline std::pair<int, int> get_window_size_wh() noexcept

--- a/AlmondShell/src/aengine.cpp
+++ b/AlmondShell/src/aengine.cpp
@@ -38,6 +38,7 @@
 #include "acommandline.hpp"
 #include "awindowdata.hpp"
 #include "ascene.hpp"
+#include "ainput.hpp"
   
 // Code Analysis
 #include "acodeinspector.hpp"
@@ -2013,6 +2014,8 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
                 L"Error", MB_ICONERROR | MB_OK);
             return -1;
         }
+
+        almondnamespace::input::designate_polling_thread_to_current();
 
         mgr.StartRenderThreads();
         mgr.ArrangeDockedWindowsGrid();


### PR DESCRIPTION
## Summary
- add a thread designation guard to the global input polling routines so render threads cannot clobber shared input state when multi-context rendering is enabled
- register the main thread as the input polling owner before multicontext render threads start
- ensure the SFML backend drains its event queue and releases its GL context each frame to avoid blocking other contexts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d699db946883338504a3b41646d55e