### PR TITLE
Poll input from WinMain main loop

### DIFF
--- a/AlmondShell/src/aengine.cpp
+++ b/AlmondShell/src/aengine.cpp
@@ -2039,6 +2039,12 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
                 else { TranslateMessage(&msg); DispatchMessage(&msg); }
             }
 
+            // Ensure input state is refreshed from the main thread before any
+            // context-specific processing happens.  Rendering threads are now
+            // gated from polling directly, so the designated polling thread
+            // (WinMain) must keep the shared state up to date.
+            almondnamespace::input::poll_input();
+
             // Update all backends
             for (auto& [type, state] : almondnamespace::core::g_backends) {
                 auto update_on_ctx = [&](std::shared_ptr<almondnamespace::core::Context> ctx) -> bool {


### PR DESCRIPTION
## Summary
- refresh the global input state from WinMain after processing window messages so the designated polling thread keeps input responsive
- document why the main thread needs to poll now that render threads are gated from polling directly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d69f8055d88333acbecb96a73c6543