### PR TITLE
Fix context resize handling for OpenGL and software atlases

### DIFF
--- a/AlmondShell/include/aopenglcontext.hpp
+++ b/AlmondShell/include/aopenglcontext.hpp
@@ -58,6 +58,8 @@
 #include <stdexcept>
 #include <functional>
 #include <mutex>
+#include <algorithm>
+#include <memory>
 #include <queue>
 #include <vector>
 
@@ -308,7 +310,69 @@ namespace almondnamespace::openglcontext
         // -----------------------------------------------------------------
         ctx->width = static_cast<int>(w);
         ctx->height = static_cast<int>(h);
-        ctx->onResize = std::move(onResize);
+
+        glState.width = static_cast<unsigned int>(std::max<unsigned int>(1u, w));
+        glState.height = static_cast<unsigned int>(std::max<unsigned int>(1u, h));
+
+        auto weakCtx = std::weak_ptr<core::Context>(ctx);
+        auto* statePtr = &glState;
+        auto resizeImpl = [weakCtx, statePtr](int newW, int newH)
+        {
+            if (newW <= 0 || newH <= 0)
+                return;
+
+            const int clampedW = std::max(1, newW);
+            const int clampedH = std::max(1, newH);
+
+            statePtr->width = static_cast<unsigned int>(clampedW);
+            statePtr->height = static_cast<unsigned int>(clampedH);
+
+            HGLRC previousCtx = wglGetCurrentContext();
+            HDC previousDC = wglGetCurrentDC();
+            bool madeCurrent = false;
+            if (statePtr->hdc && statePtr->hglrc && previousCtx != statePtr->hglrc)
+            {
+                if (wglMakeCurrent(statePtr->hdc, statePtr->hglrc))
+                {
+                    madeCurrent = true;
+                }
+            }
+
+            glViewport(0, 0, clampedW, clampedH);
+
+            if (madeCurrent)
+            {
+                wglMakeCurrent(previousDC, previousCtx);
+            }
+
+            if (auto locked = weakCtx.lock())
+            {
+                locked->width = clampedW;
+                locked->height = clampedH;
+                if (locked->windowData)
+                {
+                    locked->windowData->width = clampedW;
+                    locked->windowData->height = clampedH;
+                }
+            }
+        };
+
+        auto combinedResize = resizeImpl;
+        if (onResize)
+        {
+            combinedResize = [resizeImpl, external = std::move(onResize)](int newW, int newH)
+            {
+                resizeImpl(newW, newH);
+                external(newW, newH);
+            };
+        }
+
+        glState.onResize = combinedResize;
+        ctx->onResize = combinedResize;
+        if (ctx->windowData)
+        {
+            ctx->windowData->onResize = combinedResize;
+        }
 
 
         if (!glState.hwnd) {

--- a/AlmondShell/include/aopengltextures.hpp
+++ b/AlmondShell/include/aopengltextures.hpp
@@ -47,6 +47,7 @@
 #include <iostream>
 #include <filesystem>
 #include <unordered_map>
+#include <algorithm>
 
 namespace almondnamespace::opengltextures
 {
@@ -314,9 +315,14 @@ namespace almondnamespace::opengltextures
             return;
         }
 
-        const int w = core::cli::window_width;
-        const int h = core::cli::window_height;
-        if (w == 0 || h == 0) {
+        auto& backend = get_opengl_backend();
+        int w = static_cast<int>(backend.glState.width);
+        int h = static_cast<int>(backend.glState.height);
+        if (w <= 0 || h <= 0) {
+            w = std::max(1, core::cli::window_width);
+            h = std::max(1, core::cli::window_height);
+        }
+        if (w <= 0 || h <= 0) {
             std::cerr << "[DrawSprite] ERROR: Window dimensions are zero.\n";
             return;
         }
@@ -357,7 +363,6 @@ namespace almondnamespace::opengltextures
         ensure_uploaded(*atlas);
 
         // 🔑 FIX: use backend.gpu_atlases, not global opengl_gpu_atlases
-        auto& backend = get_opengl_backend();
         auto it = backend.gpu_atlases.find(atlas);
         if (it == backend.gpu_atlases.end()) {
             std::cerr << "[DrawSprite] GPU texture not found for atlas '"


### PR DESCRIPTION
## Summary
- add resize callbacks that keep the software renderer framebuffer and context dimensions in sync when windows change size
- update the OpenGL backend to track resized dimensions, refresh the viewport, and rely on live context size when drawing atlas sprites

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da5d43b7ec83338df6965b4dfe1a70