### PR TITLE
Fix per-context input coordinates and hide menu during games

### DIFF
--- a/AlmondShell/include/acommandqueue.hpp
+++ b/AlmondShell/include/acommandqueue.hpp
@@ -18,6 +18,12 @@ namespace almondnamespace::core {
             commands.push(std::move(cmd));
         }
 
+        void clear() {
+            std::scoped_lock lock(mutex);
+            std::queue<RenderCommand> empty;
+            commands.swap(empty);
+        }
+
         bool drain() {
             std::queue<RenderCommand> localCommands;
             {

--- a/AlmondShell/include/acontext.hpp
+++ b/AlmondShell/include/acontext.hpp
@@ -142,7 +142,36 @@ namespace almondnamespace::core
             return is_key_down ? is_key_down(k) : false;
         }
         inline void get_mouse_position_safe(int& x, int& y) const noexcept {
-            if (get_mouse_position) get_mouse_position(x, y); else { x = y = 0; }
+            if (get_mouse_position) {
+                get_mouse_position(x, y);
+            }
+            else {
+                x = 0;
+                y = 0;
+            }
+
+#if defined(_WIN32)
+            if (hwnd && input::are_mouse_coords_global()) {
+                POINT pt{ x, y };
+                if (ScreenToClient(hwnd, &pt)) {
+                    RECT rc{};
+                    if (GetClientRect(hwnd, &rc) &&
+                        (pt.x < rc.left || pt.x >= rc.right ||
+                         pt.y < rc.top || pt.y >= rc.bottom)) {
+                        x = -1;
+                        y = -1;
+                    }
+                    else {
+                        x = pt.x;
+                        y = pt.y;
+                    }
+                }
+                else {
+                    x = -1;
+                    y = -1;
+                }
+            }
+#endif
         }
         inline bool is_mouse_button_held_safe(input::MouseButton b) const noexcept {
             return is_mouse_button_held ? is_mouse_button_held(b) : false;

--- a/AlmondShell/include/ainput.hpp
+++ b/AlmondShell/include/ainput.hpp
@@ -108,6 +108,15 @@ namespace almondnamespace::input // Input namespace
     inline std::atomic<int> mouseX{ 0 };
     inline std::atomic<int> mouseY{ 0 };
     inline std::atomic<int> mouseWheel{ 0 };
+    inline std::atomic<bool> mouseCoordsAreGlobal{ true };
+
+    inline void set_mouse_coords_are_global(bool value) {
+        mouseCoordsAreGlobal.store(value, std::memory_order_release);
+    }
+
+    inline bool are_mouse_coords_global() {
+        return mouseCoordsAreGlobal.load(std::memory_order_acquire);
+    }
 
     inline void designate_polling_thread(std::thread::id id) {
         g_pollingThread = id;
@@ -303,6 +312,7 @@ namespace almondnamespace::input // Input namespace
             mouseX.store(p.x, std::memory_order_relaxed);
             mouseY.store(p.y, std::memory_order_relaxed);
         }
+        set_mouse_coords_are_global(true);
 #endif // ALMOND_USING_RAYLIB
 
 #endif // ALMOND_MAIN_HEADLESS
@@ -448,6 +458,7 @@ inline void poll_input()
         mouseX.store(pt.x, std::memory_order_relaxed);
         mouseY.store(pt.y, std::memory_order_relaxed);
     }
+    set_mouse_coords_are_global(true);
 
     // Mouse wheel: typically requires processing WM_MOUSEWHEEL in window proc,
     // but here you might want to reset or accumulate wheel delta externally.
@@ -499,6 +510,7 @@ inline void poll_input() // macOS input polling
     CGPoint loc = CGEventGetLocation(event);
     mouseX.store(static_cast<int>(loc.x), std::memory_order_relaxed);
     mouseY.store(static_cast<int>(loc.y), std::memory_order_relaxed);
+    set_mouse_coords_are_global(true);
     CFRelease(event);
 }
 
@@ -576,6 +588,7 @@ inline void poll_input(Display * display, Window window) // Linux input polling 
             {
                 mouseX.store(event.xmotion.x, std::memory_order_relaxed);
                 mouseY.store(event.xmotion.y, std::memory_order_relaxed);
+                set_mouse_coords_are_global(false);
                 break;
             }
         }

--- a/AlmondShell/include/araylibcontextinput.hpp
+++ b/AlmondShell/include/araylibcontextinput.hpp
@@ -125,6 +125,7 @@ namespace almondnamespace::raylibcontext {
         // Mouse position
         mouseX.store(GetMouseX(), std::memory_order_relaxed);
         mouseY.store(GetMouseY(), std::memory_order_relaxed);
+        set_mouse_coords_are_global(false);
 
         // Mouse wheel (Raylib returns float, use int for your API)
         mouseWheel.store(static_cast<int>(GetMouseWheelMove()), std::memory_order_relaxed);

--- a/AlmondShell/src/aengine.cpp
+++ b/AlmondShell/src/aengine.cpp
@@ -2054,69 +2054,63 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 
                     bool ctxRunning = win->running;
 
+                    auto begin_scene = [&](auto makeScene, SceneID id) {
+                        auto clear_commands = [](const std::shared_ptr<almondnamespace::core::Context>& context) {
+                            if (context && context->windowData) {
+                                context->windowData->commandQueue.clear();
+                            }
+                        };
+
+                        for (auto& backendEntry : almondnamespace::core::g_backends) {
+                            auto& backendState = backendEntry.second;
+                            clear_commands(backendState.master);
+                            for (auto& dup : backendState.duplicates) {
+                                clear_commands(dup);
+                            }
+                        }
+
+                        menu.cleanup();
+                        if (g_activeScene) {
+                            g_activeScene->unload();
+                        }
+                        g_activeScene = makeScene();
+                        g_activeScene->load();
+                        g_sceneID = id;
+                    };
+
                     // --- Scene dispatch ---
                     switch (g_sceneID) {
                     case SceneID::Menu: {
                         if (auto choice = menu.update_and_draw(ctx, win)) {
                             if (*choice == almondnamespace::menu::Choice::Snake) {
-                                if (g_activeScene) g_activeScene->unload();
-                                g_activeScene = std::make_unique<almondnamespace::snake::SnakeScene>();
-                                g_activeScene->load();
-                                g_sceneID = SceneID::Snake;
+                                begin_scene([] { return std::make_unique<almondnamespace::snake::SnakeScene>(); }, SceneID::Snake);
                             }
                             else if (*choice == almondnamespace::menu::Choice::Tetris) {
-                                if (g_activeScene) g_activeScene->unload();
-                                g_activeScene = std::make_unique<almondnamespace::tetris::TetrisScene>();
-                                g_activeScene->load();
-                                g_sceneID = SceneID::Tetris;
+                                begin_scene([] { return std::make_unique<almondnamespace::tetris::TetrisScene>(); }, SceneID::Tetris);
                             }
                             else if (*choice == almondnamespace::menu::Choice::Pacman) {
-                                if (g_activeScene) g_activeScene->unload();
-                                g_activeScene = std::make_unique<almondnamespace::pacman::PacmanScene>();
-                                g_activeScene->load();
-                                g_sceneID = SceneID::Pacman;
+                                begin_scene([] { return std::make_unique<almondnamespace::pacman::PacmanScene>(); }, SceneID::Pacman);
                             }
                             else if (*choice == almondnamespace::menu::Choice::Sokoban) {
-                                if (g_activeScene) g_activeScene->unload();
-                                g_activeScene = std::make_unique<almondnamespace::sokoban::SokobanScene>();
-                                g_activeScene->load();
-                                g_sceneID = SceneID::Sokoban;
+                                begin_scene([] { return std::make_unique<almondnamespace::sokoban::SokobanScene>(); }, SceneID::Sokoban);
                             }
                             else if (*choice == almondnamespace::menu::Choice::Bejeweled) {
-                                if (g_activeScene) g_activeScene->unload();
-                                g_activeScene = std::make_unique<almondnamespace::match3::Match3Scene>();
-                                g_activeScene->load();
-                                g_sceneID = SceneID::Match3;
+                                begin_scene([] { return std::make_unique<almondnamespace::match3::Match3Scene>(); }, SceneID::Match3);
                             }
                             else if (*choice == almondnamespace::menu::Choice::Puzzle) {
-                                if (g_activeScene) g_activeScene->unload();
-                                g_activeScene = std::make_unique<almondnamespace::sliding::SlidingScene>();
-                                g_activeScene->load();
-                                g_sceneID = SceneID::Sliding;
+                                begin_scene([] { return std::make_unique<almondnamespace::sliding::SlidingScene>(); }, SceneID::Sliding);
                             }
                             else if (*choice == almondnamespace::menu::Choice::Minesweep) {
-                                if (g_activeScene) g_activeScene->unload();
-                                g_activeScene = std::make_unique<almondnamespace::minesweeper::MinesweeperScene>();
-                                g_activeScene->load();
-                                g_sceneID = SceneID::Minesweeper;
+                                begin_scene([] { return std::make_unique<almondnamespace::minesweeper::MinesweeperScene>(); }, SceneID::Minesweeper);
                             }
                             else if (*choice == almondnamespace::menu::Choice::Fourty) {
-                                if (g_activeScene) g_activeScene->unload();
-                                g_activeScene = std::make_unique<almondnamespace::game2048::Game2048Scene>();
-                                g_activeScene->load();
-                                g_sceneID = SceneID::Game2048;
+                                begin_scene([] { return std::make_unique<almondnamespace::game2048::Game2048Scene>(); }, SceneID::Game2048);
                             }
                             else if (*choice == almondnamespace::menu::Choice::Sandsim) {
-                                if (g_activeScene) g_activeScene->unload();
-                                g_activeScene = std::make_unique<almondnamespace::sandsim::SandSimScene>();
-                                g_activeScene->load();
-                                g_sceneID = SceneID::Sandsim;
+                                begin_scene([] { return std::make_unique<almondnamespace::sandsim::SandSimScene>(); }, SceneID::Sandsim);
                             }
                             else if (*choice == almondnamespace::menu::Choice::Cellular) {
-                                if (g_activeScene) g_activeScene->unload();
-                                g_activeScene = std::make_unique<almondnamespace::cellular::CellularScene>();
-                                g_activeScene->load();
-                                g_sceneID = SceneID::Cellular;
+                                begin_scene([] { return std::make_unique<almondnamespace::cellular::CellularScene>(); }, SceneID::Cellular);
                             }
                             else if (*choice == almondnamespace::menu::Choice::Settings) {
                                 std::cout << "[Menu] Settings selected.\n";


### PR DESCRIPTION
## Summary
- track whether polled mouse coordinates are global and convert them to each context's client space before use
- add a command queue clear helper and reset menu state when launching games so the overlay no longer draws over gameplay

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da8556f3e88333a405588a851da2e2