### PR TITLE
Improve backend context concurrency for texture handling

### DIFF
--- a/AlmondShell/include/acontext.hpp
+++ b/AlmondShell/include/acontext.hpp
@@ -43,6 +43,7 @@
 #include <cstdint>
 #include <mutex>
 #include <queue>
+#include <shared_mutex>
 
 namespace almondnamespace::core
 {
@@ -226,6 +227,7 @@ namespace almondnamespace::core
 
     using BackendMap = std::map<ContextType, BackendState>;
     extern BackendMap g_backends;
+    extern std::shared_mutex g_backendsMutex;
 
     void InitializeAllContexts();
     std::shared_ptr<Context> CloneContext(const Context& prototype);


### PR DESCRIPTION
## Summary
- guard the global backend registry with a shared mutex and update context iteration to work on safe snapshots
- synchronize OpenGL texture uploads/draws and multi-context window setup with the new locking primitives
- update the engine loop and Raylib backend accessor to use the shared mutex while retaining per-backend cleanup semantics

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da956a1d4c8333aebcdce7e8827774