### PR TITLE
Avoid dependency on sf::RenderStates::Default to fix link error

### DIFF
--- a/AlmondShell/include/asfmltextures.hpp
+++ b/AlmondShell/include/asfmltextures.hpp
@@ -266,7 +266,13 @@ namespace almondnamespace::sfmlcontext
             std::cerr << "[SFML_DrawSprite] Render window is not open.\n";
             return;
         }
-        s_sfmlstate.window.sfml_window->draw(sprite);
+        // Explicitly pass a default-constructed RenderStates instance instead of relying on
+        // sf::RenderStates::Default. The latter is defined in the SFML graphics library and can
+        // trigger unresolved external symbol errors when the linker fails to pull in the
+        // necessary static definition. Constructing the states locally avoids that dependency
+        // while preserving the default rendering behaviour.
+        sf::RenderStates renderStates{};
+        s_sfmlstate.window.sfml_window->draw(sprite, renderStates);
         //draw test rectangle for debugging
 //sf::RectangleShape test(sf::Vector2f(50, 50));
 //test.setFillColor(sf::Color::Red);


### PR DESCRIPTION
## Summary
- avoid relying on sf::RenderStates::Default when drawing sprites with the SFML backend
- instantiate sf::RenderStates locally to prevent unresolved symbol link errors while keeping default behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da9ea47bfc833388c44cee0bcb22c7