### PR TITLE
Fix menu atlas rendering across SDL and Raylib contexts

### DIFF
--- a/AlmondShell/include/araylibcontext.hpp
+++ b/AlmondShell/include/araylibcontext.hpp
@@ -255,6 +255,7 @@ namespace almondnamespace::raylibcontext
     // Per-frame event processing
     // ──────────────────────────────────────────────
     inline bool raylib_process(std::shared_ptr<core::Context> ctx, core::CommandQueue& queue) {
+        (void)ctx;
         if (!s_raylibstate.running || WindowShouldClose()) {
             s_raylibstate.running = false;
             return true;
@@ -282,9 +283,9 @@ namespace almondnamespace::raylibcontext
 
 
         BeginDrawing();
-       // ClearBackground(RED);
         ClearBackground(Color{ r, g, b, 255 });
-        //DRAWTEXT(TextFormat("Raylib Rendering OK"), 200, 160, 40, BLUE);
+
+        queue.drain();
 
         EndDrawing();
 


### PR DESCRIPTION
## Summary
- update the menu overlay to enqueue draw calls through the active context so every backend can render the atlas slices
- repair the SDL backend initialization and frame loop so atlases upload correctly and queued draw commands run before presenting
- run the Raylib frame loop through the command queue each frame so menu sprites render on that backend

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daafef7ab483339ab7b7e614ca899c