### PR TITLE
Fix atlas sprite rendering across backends

### DIFF
--- a/AlmondShell/include/araylibrenderer.hpp
+++ b/AlmondShell/include/araylibrenderer.hpp
@@ -34,6 +34,7 @@
 
 #include <iostream>
 //#undef Rectangle // Avoid conflict with raylib Rectangle
+#include <algorithm>
 
 #include <raylib.h> // Ensure this is included after platform-specific headers
 namespace almondnamespace::raylibcontext
@@ -115,13 +116,36 @@ namespace almondnamespace::raylibcontext
             static_cast<float>(region.height)
         };
 
-        // If width/height <= 0, use native sprite size
-        float drawWidth = (width > 0.f) ? width : static_cast<float>(region.width);
-        float drawHeight = (height > 0.f) ? height : static_cast<float>(region.height);
+        int screenW = GetRenderWidth();
+        int screenH = GetRenderHeight();
+
+        float drawX = x;
+        float drawY = y;
+        float drawWidth = width;
+        float drawHeight = height;
+
+        const bool widthNormalized = drawWidth > 0.f && drawWidth <= 1.f;
+        const bool heightNormalized = drawHeight > 0.f && drawHeight <= 1.f;
+
+        if (widthNormalized) {
+            if (drawX >= 0.f && drawX <= 1.f)
+                drawX *= static_cast<float>(screenW);
+            drawWidth = std::max(drawWidth * static_cast<float>(screenW), 1.0f);
+        }
+        if (heightNormalized) {
+            if (drawY >= 0.f && drawY <= 1.f)
+                drawY *= static_cast<float>(screenH);
+            drawHeight = std::max(drawHeight * static_cast<float>(screenH), 1.0f);
+        }
+
+        if (drawWidth <= 0.f)
+            drawWidth = static_cast<float>(region.width);
+        if (drawHeight <= 0.f)
+            drawHeight = static_cast<float>(region.height);
 
         Rect destRect{
-            x,
-            y,
+            drawX,
+            drawY,
             drawWidth,
             drawHeight
         };

--- a/AlmondShell/include/asdltextures.hpp
+++ b/AlmondShell/include/asdltextures.hpp
@@ -41,6 +41,7 @@
 #include <vector>
 #include <unordered_map>
 #include <iostream>
+#include <algorithm>
 
 namespace almondnamespace::sdltextures
 {
@@ -285,11 +286,41 @@ namespace almondnamespace::sdltextures
             return;
         }
 
+        int outputW = w;
+        int outputH = h;
+        if (sdl_renderer) {
+            SDL_GetRendererOutputSize(sdl_renderer, &outputW, &outputH);
+        }
+
+        float drawX = static_cast<float>(x);
+        float drawY = static_cast<float>(y);
+        float drawWidth = static_cast<float>(width);
+        float drawHeight = static_cast<float>(height);
+
+        const bool widthNormalized = drawWidth > 0.f && drawWidth <= 1.f;
+        const bool heightNormalized = drawHeight > 0.f && drawHeight <= 1.f;
+
+        if (widthNormalized) {
+            if (drawX >= 0.f && drawX <= 1.f)
+                drawX *= static_cast<float>(outputW);
+            drawWidth = std::max(drawWidth * static_cast<float>(outputW), 1.0f);
+        }
+        if (heightNormalized) {
+            if (drawY >= 0.f && drawY <= 1.f)
+                drawY *= static_cast<float>(outputH);
+            drawHeight = std::max(drawHeight * static_cast<float>(outputH), 1.0f);
+        }
+
+        if (drawWidth <= 0.f)
+            drawWidth = static_cast<float>(region.width);
+        if (drawHeight <= 0.f)
+            drawHeight = static_cast<float>(region.height);
+
         SDL_FRect dstRect{
-            static_cast<float>(x),
-            static_cast<float>(y),
-            static_cast<float>(width),
-            static_cast<float>(height)
+            drawX,
+            drawY,
+            drawWidth,
+            drawHeight
         };
 
         SDL_FRect srcRect{


### PR DESCRIPTION
## Summary
- normalize sprite position and size handling so normalized coordinates expand to window pixels across OpenGL, SDL, Raylib, and software renderers
- restore proper OpenGL atlas UV setup and drop the software renderer debug atlas overlay to display the requested sprites again

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dba8cb8d2c833393f9805ec54e1a55