### PR TITLE
Fix atlas handle indexing across renderers

### DIFF
--- a/AlmondShell/include/aopengltextures.hpp
+++ b/AlmondShell/include/aopengltextures.hpp
@@ -285,12 +285,13 @@ namespace almondnamespace::opengltextures
         s_generation.fetch_add(1, std::memory_order_relaxed);
     }
 
-    inline Handle load_atlas(const TextureAtlas& atlas, int atlasIndex = 0) {
+    inline Handle load_atlas(const TextureAtlas& atlas, int atlasIndex = -1) {
         atlasmanager::ensure_uploaded(atlas);
-        return make_handle(atlasIndex, 0);
+        const int resolvedIndex = (atlasIndex >= 0) ? atlasIndex : atlas.get_index();
+        return make_handle(resolvedIndex, 0);
     }
 
-    inline Handle atlas_add_texture(TextureAtlas& atlas, const std::string& id, const ImageData& img) 
+    inline Handle atlas_add_texture(TextureAtlas& atlas, const std::string& id, const ImageData& img)
     {
         auto rgba = ensure_rgba(img);
 
@@ -307,7 +308,7 @@ namespace almondnamespace::opengltextures
 
         atlasmanager::ensure_uploaded(atlas);
 
-        return make_handle(0, addedOpt->index);
+        return make_handle(atlas.get_index(), addedOpt->index);
     }
 
     inline uint32_t upload_texture(const uint8_t* pixels, int width, int height) 

--- a/AlmondShell/include/araylibtextures.hpp
+++ b/AlmondShell/include/araylibtextures.hpp
@@ -206,9 +206,10 @@ namespace almondnamespace::raylibtextures
         s_generation.fetch_add(1, std::memory_order_relaxed);
     }
 
-    inline Handle load_atlas(const TextureAtlas& atlas, int atlasIndex = 0) {
+    inline Handle load_atlas(const TextureAtlas& atlas, int atlasIndex = -1) {
         atlasmanager::ensure_uploaded(atlas);
-        return make_handle(atlasIndex, 0);
+        const int resolvedIndex = (atlasIndex >= 0) ? atlasIndex : atlas.get_index();
+        return make_handle(resolvedIndex, 0);
     }
 
     inline Handle atlas_add_texture(TextureAtlas& atlas, const std::string& id, const ImageData& img)
@@ -228,7 +229,7 @@ namespace almondnamespace::raylibtextures
 
         atlasmanager::ensure_uploaded(atlas);
 
-        return make_handle(0, addedOpt->index);
+        return make_handle(atlas.get_index(), addedOpt->index);
     }
 
 } // namespace almondnamespace::raylibcontext

--- a/AlmondShell/include/asdltextures.hpp
+++ b/AlmondShell/include/asdltextures.hpp
@@ -196,12 +196,13 @@ namespace almondnamespace::sdltextures
         upload_atlas_to_gpu(atlas);
     }
 
-    inline Handle load_atlas(const TextureAtlas& atlas, int atlasIndex = 0) {
+    inline Handle load_atlas(const TextureAtlas& atlas, int atlasIndex = -1) {
         atlasmanager::ensure_uploaded(atlas);
-        return make_handle(atlasIndex, 0);
+        const int resolvedIndex = (atlasIndex >= 0) ? atlasIndex : atlas.get_index();
+        return make_handle(resolvedIndex, 0);
     }
 
-    inline Handle atlas_add_texture(TextureAtlas& atlas, const std::string& id, const ImageData& img) 
+    inline Handle atlas_add_texture(TextureAtlas& atlas, const std::string& id, const ImageData& img)
     {
         auto rgba = ensure_rgba(img);
 
@@ -218,7 +219,7 @@ namespace almondnamespace::sdltextures
 
         atlasmanager::ensure_uploaded(atlas);
 
-        return make_handle(0, addedOpt->index);
+        return make_handle(atlas.get_index(), addedOpt->index);
     }
 
     inline void clear_gpu_atlases() noexcept 

--- a/AlmondShell/include/asfmltextures.hpp
+++ b/AlmondShell/include/asfmltextures.hpp
@@ -169,9 +169,10 @@ namespace almondnamespace::sfmlcontext
         s_generation.fetch_add(1, std::memory_order_relaxed);
     }
 
-    inline Handle load_atlas(const TextureAtlas& atlas, int atlasIndex = 0) {
+    inline Handle load_atlas(const TextureAtlas& atlas, int atlasIndex = -1) {
         atlasmanager::ensure_uploaded(atlas);
-        return make_handle(atlasIndex, 0);
+        const int resolvedIndex = (atlasIndex >= 0) ? atlasIndex : atlas.get_index();
+        return make_handle(resolvedIndex, 0);
     }
 
     inline Handle atlas_add_texture(TextureAtlas& atlas, const std::string& id, const ImageData& img) {
@@ -190,7 +191,7 @@ namespace almondnamespace::sfmlcontext
 
         atlasmanager::ensure_uploaded(atlas);
 
-        return make_handle(0, addedOpt->index);
+        return make_handle(atlas.get_index(), addedOpt->index);
     }
 
 

--- a/AlmondShell/src/acontext.cpp
+++ b/AlmondShell/src/acontext.cpp
@@ -171,22 +171,22 @@ namespace almondnamespace::core {
         uint32_t handle = 0;
         switch (type) {
 #ifdef ALMOND_USING_OPENGL
-        case ContextType::OpenGL: handle = opengltextures::load_atlas(atlas, 0); break;
+        case ContextType::OpenGL: handle = opengltextures::load_atlas(atlas, atlas.get_index()); break;
 #endif
 #ifdef ALMOND_USING_SDL
-        case ContextType::SDL:  handle = sdltextures::load_atlas(atlas, 0); break;
+        case ContextType::SDL:  handle = sdltextures::load_atlas(atlas, atlas.get_index()); break;
 #endif
 #ifdef ALMOND_USING_SFML
-        case ContextType::SFML: handle = sfmltextures::load_atlas(atlas, 0); break;
+        case ContextType::SFML: handle = sfmltextures::load_atlas(atlas, atlas.get_index()); break;
 #endif
 #ifdef ALMOND_USING_RAYLIB
-        case ContextType::RayLib: handle = raylibtextures::load_atlas(atlas, 0); break;
+        case ContextType::RayLib: handle = raylibtextures::load_atlas(atlas, atlas.get_index()); break;
 #endif
 #ifdef ALMOND_USING_VULKAN
-        case ContextType::Vulkan: handle = vulkantextures::load_atlas(atlas, 0); break;
+        case ContextType::Vulkan: handle = vulkantextures::load_atlas(atlas, atlas.get_index()); break;
 #endif
 #ifdef ALMOND_USING_DIRECTX
-        case ContextType::DirectX: handle = directxtextures::load_atlas(atlas, 0); break;
+        case ContextType::DirectX: handle = directxtextures::load_atlas(atlas, atlas.get_index()); break;
 #endif
         default:
             std::cerr << "[AddAtlasThunk] Unsupported context type\n";


### PR DESCRIPTION
## Summary
- ensure each renderer encodes the correct atlas index when loading atlases or appending textures
- propagate atlas indices through the shared AddAtlasThunk so non-software backends fetch the right atlas

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbce7dc058833399263e5492eb3c06