### PR TITLE
Improve Unix readme layout responsiveness

### DIFF
--- a/AlmondShell/unix/stylesheet.css
+++ b/AlmondShell/unix/stylesheet.css
@@ -13,8 +13,11 @@ body {
 
 
 .container {
-  width: 1100px;
+  max-width: 1100px;
+  width: 100%;
   margin: 0 auto;
+  padding: 0 16px;
+  box-sizing: border-box;
 }
 
 section {
@@ -27,7 +30,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 table, tr {
-    width: 1100px;
+    width: 100%;
     padding: 0px;
     vertical-align: top;
   }
@@ -67,6 +70,12 @@ h1, h2 {
   width: 100%;
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
+}
+
+#main_content > td {
+  flex: 1 1 300px;
+  box-sizing: border-box;
 }
 
 
@@ -104,8 +113,10 @@ ul {
         padding-left: 0;
     }
 #lpanel {
-    width: 870px;
+    width: 100%;
+    max-width: 870px;
     float: left;
+    box-sizing: border-box;
 }
 #rpanel ul {
     list-style-type: none;
@@ -115,5 +126,33 @@ ul {
     }
 #rpanel {
     background: #e7e7e7;
-    width: 230px;
+    width: 100%;
+    max-width: 230px;
+    box-sizing: border-box;
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+}
+
+@media (max-width: 960px) {
+    .container {
+        padding: 0 12px;
+    }
+
+    #main_content {
+        flex-direction: column;
+    }
+
+    #lpanel,
+    #rpanel {
+        max-width: none;
+        width: 100%;
+        float: none;
+    }
+
+    #rpanel {
+        margin-top: 24px;
+    }
 }


### PR DESCRIPTION
## Summary
- make the unix readme layout responsive by letting the container shrink with the viewport
- allow the main content columns to wrap and images to scale to avoid overflow
- adjust small-screen styling so the resource sidebar stacks underneath the main content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc287999b88333a5c85e5f01941da9