### PR TITLE
Fix menu overlay rendering on SDL, Raylib, and OpenGL

### DIFF
--- a/AlmondShell/include/acontextmultiplexer.hpp
+++ b/AlmondShell/include/acontextmultiplexer.hpp
@@ -133,6 +133,8 @@ namespace almondnamespace::core
 
         WindowData* findWindowByHWND(HWND hwnd);
         const WindowData* findWindowByHWND(HWND hwnd) const;
+        WindowData* findWindowByContext(const std::shared_ptr<core::Context>& ctx);
+        const WindowData* findWindowByContext(const std::shared_ptr<core::Context>& ctx) const;
     private:
         // ---- Internal State ----
         std::vector<std::unique_ptr<WindowData>> windows;

--- a/AlmondShell/src/acontext.cpp
+++ b/AlmondShell/src/acontext.cpp
@@ -447,7 +447,7 @@ namespace almondnamespace::core {
         openglContext->is_mouse_button_down = [](input::MouseButton b) { return input::is_mouse_button_down(b); };
 
         openglContext->registry_get = [](const char*) { return 0; };
-        openglContext->draw_sprite = [](SpriteHandle, std::span<const TextureAtlas* const>, float, float, float, float) {};
+        openglContext->draw_sprite = opengltextures::draw_sprite;
 
         openglContext->add_texture = [&](TextureAtlas& a, const std::string& n, const ImageData& i) {
             return AddTextureThunk(a, n, i, ContextType::OpenGL);

--- a/AlmondShell/src/acontextmultiplexer.cpp
+++ b/AlmondShell/src/acontextmultiplexer.cpp
@@ -89,6 +89,26 @@ namespace almondnamespace::core
         return (it != windows.end()) ? it->get() : nullptr;
     }
 
+    WindowData* MultiContextManager::findWindowByContext(const std::shared_ptr<core::Context>& ctx) {
+        if (!ctx) return nullptr;
+        std::scoped_lock lock(windowsMutex);
+        auto it = std::find_if(windows.begin(), windows.end(),
+            [&](const std::unique_ptr<WindowData>& w) {
+                return w && w->context && w->context.get() == ctx.get();
+            });
+        return (it != windows.end()) ? it->get() : nullptr;
+    }
+
+    const WindowData* MultiContextManager::findWindowByContext(const std::shared_ptr<core::Context>& ctx) const {
+        if (!ctx) return nullptr;
+        std::scoped_lock lock(windowsMutex);
+        auto it = std::find_if(windows.begin(), windows.end(),
+            [&](const std::unique_ptr<WindowData>& w) {
+                return w && w->context && w->context.get() == ctx.get();
+            });
+        return (it != windows.end()) ? it->get() : nullptr;
+    }
+
     // ======================================================
     // Inline Implementations
     // ======================================================

--- a/AlmondShell/src/aengine.cpp
+++ b/AlmondShell/src/aengine.cpp
@@ -2075,7 +2075,10 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
                 auto update_on_ctx = [&](std::shared_ptr<almondnamespace::core::Context> ctx) -> bool {
                     if (!ctx) return true;
                     auto* win = mgr.findWindowByHWND(ctx->hwnd);
-                    if (!win) return false;
+                    if (!win)
+                        win = mgr.findWindowByContext(ctx);
+                    if (!win)
+                        return true; // window not ready yet
 
                     bool ctxRunning = win->running;
 


### PR DESCRIPTION
## Summary
- expose helpers on `MultiContextManager` to find a window from its context pointer
- teach the main loop to use the new helper so non-HWND backends still receive menu draw commands
- wire the OpenGL backend to use the atlas-aware sprite draw routine

## Testing
- not run (platform-specific rendering code)

------
https://chatgpt.com/codex/tasks/task_e_68dc343d05648333bca6f108ffd73242