### PR TITLE
Fix menu button ordering and OpenGL atlas orientation

### DIFF
--- a/AlmondShell/include/aguimenu.hpp
+++ b/AlmondShell/include/aguimenu.hpp
@@ -218,11 +218,11 @@ namespace almondnamespace::menu
                 const int rowFromTop = static_cast<int>(idx) / ExpectedColumns;
                 const int colFromLeft = static_cast<int>(idx) % ExpectedColumns;
 
-                // The sprite sheet is authored starting at the bottom edge, so we
-                // flip the row index to keep logical index 0 at the top-left of the
-                // menu grid while preserving the original left-to-right ordering of
-                // columns.
-                const int row = ExpectedRowsPerHalf - 1 - rowFromTop;
+                // The atlas is authored in row-major order from the top-left corner,
+                // matching the logical button ordering.  Preserve that layout so
+                // "Snake" appears in the top-left slot and "Quit" in the
+                // bottom-right slot across every backend.
+                const int row = rowFromTop;
                 const int col = colFromLeft;
 
                 const int normalX = col * spriteW;

--- a/AlmondShell/include/aopengltextures.hpp
+++ b/AlmondShell/include/aopengltextures.hpp
@@ -424,8 +424,11 @@ namespace almondnamespace::opengltextures
 
         const float u0 = region.u1;
         const float du = region.u2 - region.u1;
-        const float v0 = region.v1;
-        const float dv = region.v2 - region.v1;
+        // OpenGL expects the texture origin in the bottom-left corner, while the
+        // atlas data is stored with a top-left origin.  Flip the V span so the
+        // sprite appears upright without modifying shared atlas data.
+        const float v0 = region.v2;
+        const float dv = region.v1 - region.v2;
 
         if (backend.glState.uUVRegionLoc >= 0)
             glUniform4f(backend.glState.uUVRegionLoc, u0, v0, du, dv);


### PR DESCRIPTION
## Summary
- preserve the menu atlas' top-left-to-bottom-right ordering so the buttons match their intended layout
- flip the OpenGL UV span vertically so sprites render upright without altering shared atlas data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1bae175848333960a59f1f6d64e6e